### PR TITLE
(#5) feat: AI 기반 모임 생성 API 구현 완료

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -33,6 +33,8 @@ dependencies {
 	annotationProcessor("org.projectlombok:lombok")
 	testImplementation("org.springframework.boot:spring-boot-starter-test")
 	testRuntimeOnly("org.junit.platform:junit-platform-launcher")
+	implementation("org.springframework.boot:spring-boot-starter-webflux")
+
 }
 
 tasks.withType<Test> {

--- a/src/main/java/kr/ai/nemo/exception/global/CustomException.java
+++ b/src/main/java/kr/ai/nemo/exception/global/CustomException.java
@@ -1,0 +1,13 @@
+package kr.ai.nemo.exception.global;
+
+import lombok.Getter;
+
+@Getter
+public class CustomException extends RuntimeException {
+  private final ErrorCode errorCode;
+
+  public CustomException(ErrorCode errorCode) {
+    super(errorCode.getMessage());
+    this.errorCode = errorCode;
+  }
+}

--- a/src/main/java/kr/ai/nemo/exception/global/ErrorCode.java
+++ b/src/main/java/kr/ai/nemo/exception/global/ErrorCode.java
@@ -1,0 +1,35 @@
+package kr.ai.nemo.exception.global;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+@RequiredArgsConstructor
+@Getter
+public enum ErrorCode {
+
+  // 400 BAD REQUEST
+  INVALID_REQUEST("INVALID_REQUEST", "입력값이 유효하지 않습니다.", HttpStatus.BAD_REQUEST),
+  INVALID_ENUM("INVALID_ENUM", "올바르지 않은 타입입니다.", HttpStatus.BAD_REQUEST),
+  MISSING_REQUIRED_PARAMETER("MISSING_REQUIRED_PARAMETER", "필수 요청 파라미터가 누락되었습니다.", HttpStatus.BAD_REQUEST),
+
+  // 401 UNAUTHORIZED
+  UNAUTHORIZED("UNAUTHORIZED", "인증이 필요합니다.", HttpStatus.UNAUTHORIZED),
+  INVALID_TOKEN("INVALID_TOKEN", "토큰이 유효하지 않습니다.", HttpStatus.UNAUTHORIZED),
+  EXPIRED_TOKEN("EXPIRED_TOKEN", "토큰이 만료되었습니다.", HttpStatus.UNAUTHORIZED),
+
+  // 403 FORBIDDEN
+  ACCESS_DENIED("NO_PERMISSION", "접근 권한이 없습니다.", HttpStatus.FORBIDDEN),
+
+  // 404 NOT FOUND
+  USER_NOT_FOUND("USER_NOT_FOUND", "사용자를 찾을 수 없습니다.", HttpStatus.NOT_FOUND),
+
+  // 500 INTERNAL SERVER ERROR
+  INTERNAL_SERVER_ERROR("INTERNAL_SERVER_ERROR", "서버 오류가 발생했습니다.", HttpStatus.INTERNAL_SERVER_ERROR),
+  AI_SERVER_CONNECTION_FAILED("AI_SERVER_CONNECTION_FAILED", "AI 서버 연결에 실패했습니다.", HttpStatus.INTERNAL_SERVER_ERROR);
+
+
+  private final String code;
+  private final String message;
+  private final HttpStatus httpStatus;
+}

--- a/src/main/java/kr/ai/nemo/exception/global/ErrorResponse.java
+++ b/src/main/java/kr/ai/nemo/exception/global/ErrorResponse.java
@@ -1,0 +1,22 @@
+package kr.ai.nemo.exception.global;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class ErrorResponse {
+  private String errorCode;
+  private String errorMessage;
+  private int httpStatus;
+  private Object data;
+
+  public static ErrorResponse of(ErrorCode errorCode) {
+    return new ErrorResponse(
+        errorCode.getCode(),
+        errorCode.getMessage(),
+        errorCode.getHttpStatus().value(),
+        null
+    );
+  }
+}

--- a/src/main/java/kr/ai/nemo/exception/global/GlobalExceptionHandler.java
+++ b/src/main/java/kr/ai/nemo/exception/global/GlobalExceptionHandler.java
@@ -1,0 +1,41 @@
+package kr.ai.nemo.exception.global;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.http.converter.HttpMessageNotReadableException;
+import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.MissingServletRequestParameterException;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+@RestControllerAdvice
+public class GlobalExceptionHandler {
+
+  @ExceptionHandler(CustomException.class)
+  public ResponseEntity<ErrorResponse> handleBaseException(CustomException e) {
+    return ResponseEntity
+        .status(e.getErrorCode().getHttpStatus())
+        .body(ErrorResponse.of(e.getErrorCode()));
+  }
+
+  @ExceptionHandler(MethodArgumentNotValidException.class)
+  public ResponseEntity<ErrorResponse> handleValidationException(MethodArgumentNotValidException e) {
+    return ResponseEntity
+        .status(HttpStatus.BAD_REQUEST)
+        .body(ErrorResponse.of(ErrorCode.INVALID_REQUEST));
+  }
+
+  @ExceptionHandler(MissingServletRequestParameterException.class)
+  public ResponseEntity<ErrorResponse> handleMissingParamException(MethodArgumentNotValidException e) {
+    return ResponseEntity
+        .status(HttpStatus.BAD_REQUEST)
+        .body(ErrorResponse.of(ErrorCode.MISSING_REQUIRED_PARAMETER));
+  }
+
+  @ExceptionHandler(HttpMessageNotReadableException.class)
+  public ResponseEntity<ErrorResponse> handleHttpMessageNotReadableException(HttpMessageNotReadableException e) {
+    return ResponseEntity
+        .status(HttpStatus.BAD_REQUEST)
+        .body(ErrorResponse.of(ErrorCode.INVALID_ENUM));
+  }
+}

--- a/src/main/java/kr/ai/nemo/group/controller/GroupController.java
+++ b/src/main/java/kr/ai/nemo/group/controller/GroupController.java
@@ -1,0 +1,28 @@
+package kr.ai.nemo.group.controller;
+
+import jakarta.validation.Valid;
+import kr.ai.nemo.group.dto.GroupAiGenerateRequest;
+import kr.ai.nemo.group.dto.GroupAiGenerateResponse;
+import kr.ai.nemo.group.service.AiGroupGenerateClient;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/v1/groups")
+@RequiredArgsConstructor
+public class GroupController {
+
+  private final AiGroupGenerateClient aiGroupGenerateClient;
+
+  @PostMapping("/ai-generate")
+  public ResponseEntity<GroupAiGenerateResponse> generateGroupInfo(@Valid @RequestBody GroupAiGenerateRequest request) {
+
+    GroupAiGenerateResponse aiResponse = aiGroupGenerateClient.call(request);
+
+    return ResponseEntity.ok(aiResponse);
+  }
+}

--- a/src/main/java/kr/ai/nemo/group/domain/Category.java
+++ b/src/main/java/kr/ai/nemo/group/domain/Category.java
@@ -1,0 +1,23 @@
+package kr.ai.nemo.group.domain;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+@Getter
+public enum Category {
+  PET("반려동물"),
+  SPORTS("스포츠"),
+  READING_DISCUSSION("독서/토론"),
+  CULTURE_ART("문화/예술"),
+  LANGUAGE_FOREIGN("외국/언어"),
+  GAMES_ENTERTAINMENT("게임/오락"),
+  MUSIC_INSTRUMENT("음악/악기"),
+  IT_DEVELOPMENT("IT/개발"),
+  CAREER_EMPLOYMENT("취업/커리어"),
+  ECONOMY_FINANCE("경제/금융"),
+  SOCIAL_NETWORKING("친목/사교"),
+  ETC("기타");
+
+  private final String displayName;
+}

--- a/src/main/java/kr/ai/nemo/group/dto/GroupAiGenerateRequest.java
+++ b/src/main/java/kr/ai/nemo/group/dto/GroupAiGenerateRequest.java
@@ -1,0 +1,27 @@
+package kr.ai.nemo.group.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import kr.ai.nemo.group.domain.Category;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class GroupAiGenerateRequest {
+
+  @NotBlank(message = "모임명은 필수입니다.")
+  private String name;
+
+  @NotBlank(message = "모임 목표는 필수입니다.")
+  private String goal;
+
+  @NotNull(message = "모임 카테고리는 필수입니다.")
+  private Category category;
+
+  @NotBlank(message = "기간 선택은 필수입니다.")
+  private String period;
+
+  @NotNull(message = "학습계획 생성 여부 선택은 필수입니다.")
+  private boolean isPlanCreated;
+}

--- a/src/main/java/kr/ai/nemo/group/dto/GroupAiGenerateResponse.java
+++ b/src/main/java/kr/ai/nemo/group/dto/GroupAiGenerateResponse.java
@@ -1,0 +1,23 @@
+package kr.ai.nemo.group.dto;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonInclude.Include;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import lombok.Setter;
+
+@Setter
+@RequiredArgsConstructor
+@JsonInclude(Include.NON_EMPTY)
+public class GroupAiGenerateResponse {
+
+  private String name;
+
+  private String summary;
+
+  private String description;
+
+  private List<String> tags;
+
+  private String plan;
+}

--- a/src/main/java/kr/ai/nemo/group/service/AiGroupGenerateClient.java
+++ b/src/main/java/kr/ai/nemo/group/service/AiGroupGenerateClient.java
@@ -1,0 +1,39 @@
+package kr.ai.nemo.group.service;
+
+import kr.ai.nemo.exception.global.CustomException;
+import kr.ai.nemo.exception.global.ErrorCode;
+import kr.ai.nemo.group.dto.GroupAiGenerateRequest;
+import kr.ai.nemo.group.dto.GroupAiGenerateResponse;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.MediaType;
+import org.springframework.stereotype.Component;
+import org.springframework.web.reactive.function.client.WebClient;
+import org.springframework.web.reactive.function.client.WebClientResponseException;
+
+@Component
+public class AiGroupGenerateClient {
+
+  private final WebClient webClient;
+
+  public AiGroupGenerateClient(@Value("${ai.service.url:http://localhost:5000}") String baseUrl) {
+    this.webClient = WebClient.builder()
+        .baseUrl(baseUrl)
+        .build();
+  }
+
+  public GroupAiGenerateResponse call(GroupAiGenerateRequest request) {
+    try {
+      return webClient.post()
+          .uri("/ai/v1/groups/information")
+          .contentType(MediaType.APPLICATION_JSON)
+          .bodyValue(request)
+          .retrieve()
+          .bodyToMono(GroupAiGenerateResponse.class)
+          .block();
+    } catch (WebClientResponseException e) {
+      throw new CustomException(ErrorCode.AI_SERVER_CONNECTION_FAILED);
+    } catch (Exception e) {
+      throw new CustomException(ErrorCode.INTERNAL_SERVER_ERROR);
+    }
+  }
+}


### PR DESCRIPTION
- /groups/ai-generate: AI 기반 모임 정보 생성 API 신규 개발
- Category enum 정의 및 유효성 검증 적용
- ExceptionHandler 구현 및 공통 오류 코드 정리
- WebClient를 통한 AI 서버 연동 로직 작성
- HTTP 상태 코드 및 예외 응답 형식 정비

Part of #73