### PR TITLE
Merge: featue/user-login-kakao

### DIFF
--- a/.github/workflows/dev-cd.yaml
+++ b/.github/workflows/dev-cd.yaml
@@ -1,0 +1,49 @@
+name: CD - Deploy to Server (DEV)
+
+on:
+  workflow_run:
+    workflows: ["CI - Build & Upload to GCS (DEV)"]
+    types:
+      - completed # dev-ci가 끝났을 때 트리거
+
+jobs:
+  deploy:
+    # CI 성공한 경우에만 실행
+    if: ${{ github.event.workflow_run.conclusion == 'success' }}
+    runs-on: ubuntu-latest
+    environment: dev
+
+    steps:
+      # SSH로 개발 서버에 접속 후 GCS에서 배포 스크립트 및 JAR 다운로드 후 실행
+      - name: SSH and deploy from GCS
+        uses: appleboy/ssh-action@v1.0.0
+        with:
+          host: ${{ secrets.DEV_HOST }}            # GCP 개발 서버 IP
+          username: ${{ secrets.DEV_USER }}        # SSH 사용자명
+          key: ${{ secrets.DEV_SSH_KEY }}          # SSH 키 (시크릿 + BEGIN ~) + .pub은 서버 authorized_keys에 등록
+          script: |
+            echo "SSH 접속 성공, GCS에서 최신 스크립트 및 JAR 다운로드 시작"
+            
+            # 1. 디렉토리 준비 및 이동
+            mkdir -p ~/backend && cd backend
+            
+            # 2. JAR 및 스크립트 다운로드
+            gsutil cp gs://6-nemo-bucket/v1/backend-deploy/dev/latest.jar .
+            gsutil cp gs://6-nemo-bucket/v1/backend-deploy/dev/previous.jar . || true
+            gsutil cp gs://6-nemo-bucket/v1/backend-deploy/dev/deploy.sh .
+            gsutil cp gs://6-nemo-bucket/v1/backend-deploy/dev/rollback.sh .
+            gsutil cp gs://6-nemo-bucket/v1/backend-deploy/dev/validate.sh .
+            
+            # 3. 실행 권한 부여
+            chmod +x deploy.sh rollback.sh validate.sh
+            
+            # 4. 배포 실행
+            ./deploy.sh
+            
+            
+
+            
+            
+
+
+

--- a/.github/workflows/dev-ci.yaml
+++ b/.github/workflows/dev-ci.yaml
@@ -1,0 +1,61 @@
+name: CI - Build & Upload to GCS (DEV)
+
+on:
+  push:
+    branches: [develop]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+
+      # 1. 자바 환경 세팅
+      - name: Set up JDK
+        uses: actions/setup-java@v3
+        with:
+          java-version: '21'
+          distribution: 'temurin'
+
+      # 2. gradlew 실행 권한 부여
+      - name: Grant execute permission for gradlew
+        run: chmod +x ./gradlew
+
+      # 3. 빌드 (테스트 생략)
+      - name: Build without tests # pr-ci에서 테스트하므로 생략
+        run: ./gradlew clean build -x test
+
+      # 4. 업로드할 파일명 생성 (timestamp)
+      - name: Generate datetime tag
+        id: date
+        run: echo "TAG=$(date +'%Y%m%d-%H%M')" >> $GITHUB_OUTPUT
+
+      # 5. GCP 인증
+      - name: Authenticate to GCP
+        uses: google-github-actions/auth@v1
+        with:
+            credentials_json: ${{ secrets.GCP_SA_KEY }}
+
+      # 6. GCS - timestamp JAR 업로드
+      - name: Upload versioned JAR to GCS
+        uses: google-github-actions/upload-cloud-storage@v1
+        with:
+          path: build/libs/*SNAPSHOT.jar # 실행 가능한 JAR만 업로드
+          destination: gs://6-nemo-bucket/v1/backend-deploy/dev/${{ steps.date.outputs.TAG }}.jar
+
+      # 7. GCS - previous -> latest 백업
+      - name: Copy latest to previous, then upload new latest
+        run: |
+          gsutil cp gs://6-nemo-bucket/v1/backend-deploy/dev/latest.jar \
+                gs://6-nemo-bucket/v1/backend-deploy/dev/previous.jar || true
+          gsutil cp build/libs/*SNAPSHOT.jar \
+                gs://6-nemo-bucket/v1/backend-deploy/dev/latest.jar
+
+      # 8. GCS - 배포 스크립트 업로드
+      - name: Upload deploy scripts to GCS
+        uses: google-github-actions/upload-cloud-storage@v1
+        with:
+          path: deploy/
+          destination: gs://6-nemo-bucket/v1/backend-deploy/dev/

--- a/.github/workflows/pr-ci.yaml
+++ b/.github/workflows/pr-ci.yaml
@@ -1,0 +1,26 @@
+name: CI - PR Test & Lint
+on:
+  pull_request:
+    branches: [develop, main]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3 # 코드 가져오기
+
+      # 1. 자바 환경 세팅
+      - name: Set up JDK
+        uses: actions/setup-java@v3
+        with:
+          java-version: '21'
+          distribution: 'temurin'
+
+      # 2. gradlew 실행 권한 부여
+      - name: Grant execute permission for gradlew  # gradlew 실행 권한 부여
+        run: chmod +x ./gradlew
+
+      # 3. 테스트 실행
+#      - name: Run Tests (추후 테스트 코드 추가 시 추가 예정)
+#        run: ./gradlew clean test

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -35,8 +35,6 @@ dependencies {
 	testRuntimeOnly("org.junit.platform:junit-platform-launcher")
 	implementation("org.springframework.boot:spring-boot-starter-webflux")
 
-	implementation("org.springframework.boot:spring-boot-starter-actuator")
-
 }
 
 tasks.withType<Test> {

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -35,6 +35,8 @@ dependencies {
 	testRuntimeOnly("org.junit.platform:junit-platform-launcher")
 	implementation("org.springframework.boot:spring-boot-starter-webflux")
 
+	implementation("org.springframework.boot:spring-boot-starter-actuator")
+
 }
 
 tasks.withType<Test> {

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -23,18 +23,29 @@ repositories {
 	mavenCentral()
 }
 
+val jjwtVersion = "0.11.5"
+
 dependencies {
-	implementation("org.springframework.boot:spring-boot-starter-data-jpa")
-	implementation("org.springframework.boot:spring-boot-starter-validation")
+
 	implementation("org.springframework.boot:spring-boot-starter-web")
-	compileOnly("org.projectlombok:lombok")
+	implementation("org.springframework.boot:spring-boot-starter-webflux")
+	implementation("org.springframework.boot:spring-boot-starter-validation")
+	implementation("org.springframework.boot:spring-boot-starter-data-jpa")
+
+	implementation("io.jsonwebtoken:jjwt-api:$jjwtVersion")
+	runtimeOnly("io.jsonwebtoken:jjwt-impl:$jjwtVersion")
+	runtimeOnly("io.jsonwebtoken:jjwt-jackson:$jjwtVersion")
+
 	runtimeOnly("com.mysql:mysql-connector-j")
-	annotationProcessor("org.springframework.boot:spring-boot-configuration-processor")
+
+	compileOnly("org.projectlombok:lombok")
 	annotationProcessor("org.projectlombok:lombok")
+	annotationProcessor("org.springframework.boot:spring-boot-configuration-processor")
+
+	implementation("org.springframework.boot:spring-boot-starter-actuator")
+
 	testImplementation("org.springframework.boot:spring-boot-starter-test")
 	testRuntimeOnly("org.junit.platform:junit-platform-launcher")
-	implementation("org.springframework.boot:spring-boot-starter-webflux")
-
 }
 
 tasks.withType<Test> {

--- a/deploy/rollback.sh
+++ b/deploy/rollback.sh
@@ -1,0 +1,39 @@
+#!/bin/bash
+set -euo pipefail
+# -e: 에러 발생 시 스크립트 즉시 종료
+# -u: 정의되지 않은 변수 사용 시 에러
+# -o pipefail: 파이프라인에서 실패한 명령어가 있을 때 전체 실패로 처리
+
+echo "♻️ [ROLLBACK] 이전 버전으로 롤백 시작"
+
+APP_NAME="nemo-backend"
+PREV_JAR="previous.jar"
+
+# 1. 기존 프로세스 종료
+echo "🛑 롤백 전 기존 PM2 프로세스 종료: $APP_NAME"
+pm2 delete "$APP_NAME" || echo "ℹ️ 실행 중인 프로세스 없음"
+
+# 2. previous.jar 존재 여부 확인
+if [ ! -f "$PREV_JAR" ]; then
+  echo "❌ 롤백 실패: $PREV_JAR 파일이 존재하지 않음"
+  exit 1
+fi
+
+# 3. 이전 JAR 실행
+echo "🚀 이전 버전 실행 중: $PREV_JAR"
+pm2 start "java -jar $PREV_JAR" --name "$APP_NAME" --env .env
+
+# 4. 롤백 후 헬스체크 (최대 3회, 3초 간격)
+echo "🩺 롤백 후 헬스체크 시작..."
+for i in {1..3}; do
+  if ./validate.sh; then
+    echo "✅ 롤백 성공 및 헬스체크 통과"
+    exit 0
+  fi
+  echo "⏳ 헬스체크 재시도 ($i/3)..."
+  sleep 3
+done
+
+# 5. 롤백 후 헬스체크 실패
+echo "❌ 롤백 후에도 헬스체크 실패 - 수동 점검 필요"
+exit 1

--- a/deploy/validate.sh
+++ b/deploy/validate.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+set -euo pipefail
+# -e: 에러 발생 시 즉시 종료
+# -u: 정의되지 않은 변수 사용 시 에러
+# -o pipefail: 파이프라인 중 하나라도 실패 시 전체 실패 처리
+
+PORT=8080
+HEALTH_URL="http://localhost:${PORT}/actuator/health"
+
+echo "🔎 헬스체크 요청: $HEALTH_URL"
+
+# 요청 → 상태코드가 200이면 성공
+STATUS=$(curl -s -o /dev/null -w "%{http_code}" "$HEALTH_URL")
+
+if [ "$STATUS" == "200" ]; then
+  echo "✅ 헬스체크 통과 (200 OK)"
+  exit 0
+else
+  echo "❌ 헬스체크 실패 (응답 코드: $STATUS)"
+  exit 1
+fi

--- a/src/main/java/kr/ai/nemo/auth/controller/AuthController.java
+++ b/src/main/java/kr/ai/nemo/auth/controller/AuthController.java
@@ -1,0 +1,37 @@
+package kr.ai.nemo.auth.controller;
+
+import kr.ai.nemo.auth.dto.KakaoTokenResponse;
+import kr.ai.nemo.auth.dto.KakaoUserResponse;
+import kr.ai.nemo.auth.service.OauthService;
+import kr.ai.nemo.common.exception.ApiResponse;
+import kr.ai.nemo.user.dto.UserDto;
+import kr.ai.nemo.user.dto.UserLoginResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/oauth")
+@RequiredArgsConstructor
+public class AuthController {
+
+  private final OauthService oauthService;
+
+  @GetMapping("/kakao/callback")
+  public ResponseEntity<ApiResponse<UserLoginResponse>> kakaoLogin(@RequestParam("code") String code) {
+    KakaoTokenResponse tokenResponse = oauthService.getAccessToken(code);
+    KakaoUserResponse userResponse = oauthService.getUserInfo(tokenResponse.getAccessToken());
+
+    UserLoginResponse response = UserLoginResponse.builder()
+        .accessToken(accessToken)
+        .refreshToken(refreshToken)
+        .refreshTokenExpiresIn(1209600)
+        .user(UserDto.from(user))
+        .build();
+
+    return ResponseEntity.ok(ApiResponse.success(response));
+  }
+}

--- a/src/main/java/kr/ai/nemo/auth/domain/UserToken.java
+++ b/src/main/java/kr/ai/nemo/auth/domain/UserToken.java
@@ -1,0 +1,62 @@
+package kr.ai.nemo.auth.domain;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import java.time.LocalDateTime;
+import kr.ai.nemo.user.domain.User;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Entity
+@Table(name = "user_tokens")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Builder
+public class UserToken {
+
+  @Id
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
+  private Long id;
+
+  @Column(name = "provider", nullable = false)
+  private String provider;
+
+  @Setter
+  @Column(name = "refresh_token", nullable = false)
+  private String refreshToken;
+
+  @Setter
+  @Column(name = "device_info", nullable = false)
+  private String deviceInfo;
+
+  @Setter
+  @Column(name = "is_revoked", nullable = false)
+  private boolean isRevoked;
+
+  @Setter
+  @Column(name = "expires_at", nullable = false)
+  private LocalDateTime expiresAt;
+
+  @Column(name = "created_at", nullable = false, updatable = false)
+  private LocalDateTime createdAt;
+
+  @Setter
+  @Column(name = "updated_at", nullable = false)
+  private LocalDateTime updatedAt;
+
+  @ManyToOne(fetch = FetchType.LAZY)
+  @JoinColumn(name = "user_id", nullable = false)
+  private User user;
+}

--- a/src/main/java/kr/ai/nemo/auth/domain/enums/DefaultUserValue.java
+++ b/src/main/java/kr/ai/nemo/auth/domain/enums/DefaultUserValue.java
@@ -1,0 +1,8 @@
+package kr.ai.nemo.auth.domain.enums;
+
+public class DefaultUserValue {
+  public static final String UNKNOWN_EMAIL = "unknown@example.com";
+  public static final String UNKNOWN_NICKNAME = "알수없음";
+  public static final String DEFAULT_PROFILE_URL = "default_profile_url";
+}
+

--- a/src/main/java/kr/ai/nemo/auth/domain/enums/LoginDevice.java
+++ b/src/main/java/kr/ai/nemo/auth/domain/enums/LoginDevice.java
@@ -1,0 +1,6 @@
+package kr.ai.nemo.auth.domain.enums;
+
+public enum LoginDevice {
+  WEB, MOBILE
+}
+

--- a/src/main/java/kr/ai/nemo/auth/domain/enums/OAuthProvider.java
+++ b/src/main/java/kr/ai/nemo/auth/domain/enums/OAuthProvider.java
@@ -1,0 +1,6 @@
+package kr.ai.nemo.auth.domain.enums;
+
+public enum OAuthProvider {
+  KAKAO
+}
+

--- a/src/main/java/kr/ai/nemo/auth/dto/KakaoTokenResponse.java
+++ b/src/main/java/kr/ai/nemo/auth/dto/KakaoTokenResponse.java
@@ -1,0 +1,30 @@
+package kr.ai.nemo.auth.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+@AllArgsConstructor
+public class KakaoTokenResponse {
+
+  @JsonProperty("token_type")
+  private String tokenType;
+
+  @JsonProperty("access_token")
+  private String accessToken;
+
+  @JsonProperty("expires_in")
+  private int expiresIn;
+
+  @JsonProperty("refresh_token")
+  private String refreshToken;
+
+  @JsonProperty("refresh_token_expires_in")
+  private int refreshTokenExpiresIn;
+
+  @JsonProperty("scope")
+  private String scope;
+}

--- a/src/main/java/kr/ai/nemo/auth/dto/KakaoUserResponse.java
+++ b/src/main/java/kr/ai/nemo/auth/dto/KakaoUserResponse.java
@@ -1,0 +1,28 @@
+package kr.ai.nemo.auth.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Getter;
+
+@Getter
+public class KakaoUserResponse {
+
+  @JsonProperty("id")
+  private Long id;
+
+  @JsonProperty("kakao_account")
+  private KakaoAccount kakaoAccount;
+
+  @Getter
+  public static class KakaoAccount {
+    private String email;
+    private Profile profile;
+  }
+
+  @Getter
+  public static class Profile {
+    private String nickname;
+
+    @JsonProperty("profile_image_url")
+    private String profileImageUrl;
+  }
+}

--- a/src/main/java/kr/ai/nemo/auth/exception/OAuthErrorCode.java
+++ b/src/main/java/kr/ai/nemo/auth/exception/OAuthErrorCode.java
@@ -1,0 +1,28 @@
+package kr.ai.nemo.auth.exception;
+
+import lombok.Getter;
+
+@Getter
+public enum OAuthErrorCode {
+  EMPTY_ACCESS_TOKEN("카카오 액세스 토큰이 비어있습니다"),
+  EMPTY_TOKEN_RESPONSE("카카오 토큰 응답이 비어있습니다"),
+  INVALID_CODE("유효하지 않은 인가 코드"),
+  INVALID_CLIENT("잘못된 클라이언트 정보"),
+  CLIENT_ERROR("카카오 API 호출 중 클라이언트 오류"),
+  CONNECTION_ERROR("카카오 API 연결 실패"),
+  EMPTY_USER_INFO("카카오에서 사용자 정보를 불러올 수 없습니다"),
+  MISSING_USER_ID("카카오 사용자 ID가 없습니다"),
+  INVALID_ACCESS_TOKEN("유효하지 않은 액세스 토큰"),
+  USER_INFO_ERROR("카카오 사용자 정보 호출 중 오류"),
+  INVALID_USER_RESPONSE("유효하지 않은 카카오 사용자 정보"),
+  USER_PROCESSING_ERROR("사용자 정보 처리 중 오류 발생"),
+  LOGIN_ERROR("카카오 로그인 중 오류가 발생했습니다"),
+  KAKAO_AUTH_ERROR("카카오 로그인을 취소했습니다."),
+  CODE_MISSING("인가코드가 없습니다.");
+
+  private final String message;
+
+  OAuthErrorCode(String message) {
+    this.message = message;
+  }
+}

--- a/src/main/java/kr/ai/nemo/auth/exception/OAuthException.java
+++ b/src/main/java/kr/ai/nemo/auth/exception/OAuthException.java
@@ -1,0 +1,21 @@
+package kr.ai.nemo.auth.exception;
+
+import lombok.Getter;
+
+@Getter
+public class OAuthException extends RuntimeException {
+    private final String code;
+    private final String message;
+
+    public OAuthException(OAuthErrorCode errorCode) {
+        super(errorCode.getMessage());
+        this.code = errorCode.name();
+        this.message = errorCode.getMessage();
+    }
+
+    public OAuthException(OAuthErrorCode errorCode, Throwable cause) {
+        super(errorCode.getMessage(), cause);
+        this.code = errorCode.name();
+        this.message = errorCode.getMessage();
+    }
+}

--- a/src/main/java/kr/ai/nemo/auth/jwt/JwtProvider.java
+++ b/src/main/java/kr/ai/nemo/auth/jwt/JwtProvider.java
@@ -8,19 +8,24 @@ import java.nio.charset.StandardCharsets;
 import java.security.Key;
 import java.util.Date;
 import javax.crypto.spec.SecretKeySpec;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
 
+@Slf4j
 @Component
 public class JwtProvider {
 
   @Value("${jwt.secret}")
   private String secretKeyString;
 
-  private Key secretKey;
+  @Value("${jwt.access-token-validity}")
+  private long accessTokenValidity;
 
-  private static final long ACCESS_TOKEN_VALIDITY = 60 * 60 * 1000L;
-  private static final long REFRESH_TOKEN_VALIDITY = 14 * 24 * 60 * 60 * 1000L;
+  @Value("${jwt.refresh-token-validity}")
+  private long refreshTokenValidity;
+
+  private Key secretKey;
 
   @PostConstruct
   public void init() {
@@ -31,11 +36,11 @@ public class JwtProvider {
   }
 
   public String createAccessToken(Long userId) {
-    return createToken(userId, ACCESS_TOKEN_VALIDITY);
+    return createToken(userId, accessTokenValidity);
   }
 
   public String createRefreshToken(Long userId) {
-    return createToken(userId, REFRESH_TOKEN_VALIDITY);
+    return createToken(userId, refreshTokenValidity);
   }
 
   private String createToken(Long userId, long validity) {

--- a/src/main/java/kr/ai/nemo/auth/jwt/JwtProvider.java
+++ b/src/main/java/kr/ai/nemo/auth/jwt/JwtProvider.java
@@ -1,0 +1,54 @@
+package kr.ai.nemo.auth.jwt;
+
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.SignatureAlgorithm;
+import jakarta.annotation.PostConstruct;
+import java.nio.charset.StandardCharsets;
+import java.security.Key;
+import java.util.Date;
+import javax.crypto.spec.SecretKeySpec;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+@Component
+public class JwtProvider {
+
+  @Value("${jwt.secret}")
+  private String secretKeyString;
+
+  private Key secretKey;
+
+  private static final long ACCESS_TOKEN_VALIDITY = 60 * 60 * 1000L;
+  private static final long REFRESH_TOKEN_VALIDITY = 14 * 24 * 60 * 60 * 1000L;
+
+  @PostConstruct
+  public void init() {
+    this.secretKey = new SecretKeySpec(
+        secretKeyString.getBytes(StandardCharsets.UTF_8),
+        SignatureAlgorithm.HS256.getJcaName()
+    );
+  }
+
+  public String createAccessToken(Long userId) {
+    return createToken(userId, ACCESS_TOKEN_VALIDITY);
+  }
+
+  public String createRefreshToken(Long userId) {
+    return createToken(userId, REFRESH_TOKEN_VALIDITY);
+  }
+
+  private String createToken(Long userId, long validity) {
+    Claims claims = Jwts.claims().setSubject(userId.toString());
+
+    Date now = new Date();
+    Date expiry = new Date(now.getTime() + validity);
+
+    return Jwts.builder()
+        .setClaims(claims)
+        .setIssuedAt(now)
+        .setExpiration(expiry)
+        .signWith(secretKey, SignatureAlgorithm.HS256)
+        .compact();
+  }
+}

--- a/src/main/java/kr/ai/nemo/auth/repository/UserTokenRepository.java
+++ b/src/main/java/kr/ai/nemo/auth/repository/UserTokenRepository.java
@@ -1,0 +1,11 @@
+package kr.ai.nemo.auth.repository;
+
+import java.util.Optional;
+import kr.ai.nemo.auth.domain.UserToken;
+import kr.ai.nemo.user.domain.User;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface UserTokenRepository extends JpaRepository<UserToken, Long> {
+
+  Optional<UserToken> findByUserAndProvider(User user, String provider);
+}

--- a/src/main/java/kr/ai/nemo/auth/service/OauthService.java
+++ b/src/main/java/kr/ai/nemo/auth/service/OauthService.java
@@ -1,0 +1,62 @@
+package kr.ai.nemo.auth.service;
+
+import kr.ai.nemo.auth.dto.KakaoTokenResponse;
+import kr.ai.nemo.auth.dto.KakaoUserResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.*;
+import org.springframework.stereotype.Service;
+import org.springframework.util.LinkedMultiValueMap;
+import org.springframework.util.MultiValueMap;
+import org.springframework.web.client.RestTemplate;
+
+@Service
+@RequiredArgsConstructor
+public class OauthService {
+
+  private final RestTemplate restTemplate;
+
+  @Value("${oauth.kakao.rest-api-key}")
+  private String restApiKey;
+
+  @Value("${oauth.kakao.redirect-uri}")
+  private String redirectUri;
+
+  public KakaoTokenResponse getAccessToken(String code) {
+    HttpHeaders headers = new HttpHeaders();
+    headers.setContentType(MediaType.APPLICATION_FORM_URLENCODED);
+
+    MultiValueMap<String, String> params = new LinkedMultiValueMap<>();
+    params.add("grant_type", "authorization_code");
+    params.add("client_id", restApiKey);
+    params.add("redirect_uri", redirectUri);
+    params.add("code", code);
+
+    HttpEntity<MultiValueMap<String, String>> request = new HttpEntity<>(params, headers);
+
+    ResponseEntity<KakaoTokenResponse> response = restTemplate.postForEntity(
+        "https://kauth.kakao.com/oauth/token",
+        request,
+        KakaoTokenResponse.class
+    );
+
+    return response.getBody();
+  }
+
+  public KakaoUserResponse getUserInfo(String accessToken) {
+    HttpHeaders headers = new HttpHeaders();
+    headers.setBearerAuth(accessToken);
+
+    HttpEntity<Void> request = new HttpEntity<>(headers);
+
+    ResponseEntity<KakaoUserResponse> response = restTemplate.exchange(
+        "https://kapi.kakao.com/v2/user/me",
+        HttpMethod.GET,
+        request,
+        KakaoUserResponse.class
+    );
+
+    return response.getBody();
+  }
+
+}

--- a/src/main/java/kr/ai/nemo/auth/service/OauthService.java
+++ b/src/main/java/kr/ai/nemo/auth/service/OauthService.java
@@ -1,13 +1,29 @@
 package kr.ai.nemo.auth.service;
 
+import java.time.LocalDateTime;
+
+import kr.ai.nemo.auth.domain.enums.DefaultUserValue;
+import kr.ai.nemo.auth.domain.enums.LoginDevice;
+import kr.ai.nemo.auth.domain.enums.OAuthProvider;
 import kr.ai.nemo.auth.dto.KakaoTokenResponse;
 import kr.ai.nemo.auth.dto.KakaoUserResponse;
+import kr.ai.nemo.auth.exception.OAuthErrorCode;
+import kr.ai.nemo.auth.exception.OAuthException;
+import kr.ai.nemo.auth.jwt.JwtProvider;
+import kr.ai.nemo.user.domain.User;
+import kr.ai.nemo.user.domain.enums.UserStatus;
+import kr.ai.nemo.user.dto.UserDto;
+import kr.ai.nemo.user.dto.UserLoginResponse;
+import kr.ai.nemo.user.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.*;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 import org.springframework.util.LinkedMultiValueMap;
 import org.springframework.util.MultiValueMap;
+import org.springframework.web.client.HttpClientErrorException;
+import org.springframework.web.client.RestClientException;
 import org.springframework.web.client.RestTemplate;
 
 @Service
@@ -15,12 +31,45 @@ import org.springframework.web.client.RestTemplate;
 public class OauthService {
 
   private final RestTemplate restTemplate;
+  private final UserRepository userRepository;
+  private final JwtProvider jwtProvider;
+  private final UserTokenService userTokenService;
 
   @Value("${oauth.kakao.rest-api-key}")
   private String restApiKey;
 
   @Value("${oauth.kakao.redirect-uri}")
   private String redirectUri;
+
+  @Transactional
+  public UserLoginResponse loginWithKakao(String code) {
+    try {
+      KakaoTokenResponse kakaoToken = getAccessToken(code);
+      if (kakaoToken.getAccessToken() == null || kakaoToken.getAccessToken().isEmpty()) {
+        throw new OAuthException(OAuthErrorCode.EMPTY_ACCESS_TOKEN);
+      }
+
+      KakaoUserResponse userResponse = getUserInfo(kakaoToken.getAccessToken());
+      User user = handleUser(userResponse);
+
+      String accessToken = jwtProvider.createAccessToken(user.getId());
+      String refreshToken = jwtProvider.createRefreshToken(user.getId());
+
+      userTokenService.saveOrUpdateToken(user,
+          OAuthProvider.KAKAO.name(), refreshToken, LoginDevice.WEB.name(), LocalDateTime.now().plusDays(30));
+
+      return UserLoginResponse.builder()
+          .accessToken(accessToken)
+          .refreshToken(refreshToken)
+          .refreshTokenExpiresIn(1209600)
+          .user(UserDto.from(user))
+          .build();
+    } catch (OAuthException e) {
+      throw e;
+    } catch (Exception e) {
+      throw new OAuthException(OAuthErrorCode.LOGIN_ERROR, e);
+    }
+  }
 
   public KakaoTokenResponse getAccessToken(String code) {
     HttpHeaders headers = new HttpHeaders();
@@ -33,30 +82,101 @@ public class OauthService {
     params.add("code", code);
 
     HttpEntity<MultiValueMap<String, String>> request = new HttpEntity<>(params, headers);
+    try {
+      ResponseEntity<KakaoTokenResponse> response = restTemplate.postForEntity(
+          "https://kauth.kakao.com/oauth/token",
+          request,
+          KakaoTokenResponse.class
+      );
 
-    ResponseEntity<KakaoTokenResponse> response = restTemplate.postForEntity(
-        "https://kauth.kakao.com/oauth/token",
-        request,
-        KakaoTokenResponse.class
-    );
+      if (response.getBody() == null) {
+        throw new OAuthException(OAuthErrorCode.EMPTY_TOKEN_RESPONSE);
+      }
 
-    return response.getBody();
+      return response.getBody();
+    } catch (HttpClientErrorException e) {
+      if (e.getStatusCode() == HttpStatus.BAD_REQUEST) {
+        throw new OAuthException(OAuthErrorCode.INVALID_CODE, e);
+      } else if (e.getStatusCode() == HttpStatus.UNAUTHORIZED) {
+        throw new OAuthException(OAuthErrorCode.INVALID_CLIENT, e);
+      } else {
+        throw new OAuthException(OAuthErrorCode.CLIENT_ERROR, e);
+      }
+    } catch (RestClientException e) {
+      throw new OAuthException(OAuthErrorCode.CONNECTION_ERROR, e);
+    }
   }
 
   public KakaoUserResponse getUserInfo(String accessToken) {
     HttpHeaders headers = new HttpHeaders();
     headers.setBearerAuth(accessToken);
-
     HttpEntity<Void> request = new HttpEntity<>(headers);
 
-    ResponseEntity<KakaoUserResponse> response = restTemplate.exchange(
-        "https://kapi.kakao.com/v2/user/me",
-        HttpMethod.GET,
-        request,
-        KakaoUserResponse.class
-    );
+    try {
+      ResponseEntity<KakaoUserResponse> response = restTemplate.exchange(
+          "https://kapi.kakao.com/v2/user/me",
+          HttpMethod.GET,
+          request,
+          KakaoUserResponse.class
+      );
 
-    return response.getBody();
+      if (response.getBody() == null) {
+        throw new OAuthException(OAuthErrorCode.EMPTY_USER_INFO);
+      }
+      if (response.getBody().getId() == null) {
+        throw new OAuthException(OAuthErrorCode.MISSING_USER_ID);
+      }
+
+      return response.getBody();
+    } catch (HttpClientErrorException e) {
+      if (e.getStatusCode() == HttpStatus.UNAUTHORIZED) {
+        throw new OAuthException(OAuthErrorCode.INVALID_ACCESS_TOKEN, e);
+      } else {
+        throw new OAuthException(OAuthErrorCode.USER_INFO_ERROR, e);
+      }
+    } catch (RestClientException e) {
+      throw new OAuthException(OAuthErrorCode.CONNECTION_ERROR, e);
+    }
+  }
+
+  public User handleUser(KakaoUserResponse userResponse) {
+    if (userResponse == null || userResponse.getId() == null) {
+      throw new OAuthException(OAuthErrorCode.INVALID_USER_RESPONSE);
+    }
+
+    final String provider = OAuthProvider.KAKAO.name();
+    final String providerId = userResponse.getId().toString();
+
+    return userRepository.findByProviderAndProviderId(provider, providerId)
+        .orElseGet(() -> userRepository.save(createUserFromResponse(userResponse)));
+  }
+
+  private User createUserFromResponse(KakaoUserResponse userResponse) {
+    KakaoUserResponse.KakaoAccount account = userResponse.getKakaoAccount();
+    KakaoUserResponse.Profile profile = (account != null) ? account.getProfile() : null;
+
+    final String email = (account != null && account.getEmail() != null)
+        ? account.getEmail()
+        : DefaultUserValue.UNKNOWN_EMAIL;
+
+    final String nickname = (profile != null && profile.getNickname() != null)
+        ? profile.getNickname()
+        : DefaultUserValue.UNKNOWN_NICKNAME;
+
+    final String profileImageUrl = (profile != null && profile.getProfileImageUrl() != null)
+        ? profile.getProfileImageUrl()
+        : DefaultUserValue.DEFAULT_PROFILE_URL;
+
+    return User.builder()
+        .provider(OAuthProvider.KAKAO.name())
+        .providerId(userResponse.getId().toString())
+        .email(email)
+        .nickname(nickname)
+        .profileImageUrl(profileImageUrl)
+        .status(UserStatus.ACTIVE)
+        .createdAt(LocalDateTime.now())
+        .updatedAt(LocalDateTime.now())
+        .build();
   }
 
 }

--- a/src/main/java/kr/ai/nemo/auth/service/UserTokenService.java
+++ b/src/main/java/kr/ai/nemo/auth/service/UserTokenService.java
@@ -1,0 +1,57 @@
+package kr.ai.nemo.auth.service;
+
+import java.time.LocalDateTime;
+
+import kr.ai.nemo.auth.domain.UserToken;
+import kr.ai.nemo.auth.repository.UserTokenRepository;
+import kr.ai.nemo.user.domain.User;
+
+import lombok.RequiredArgsConstructor;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class UserTokenService {
+
+  private final UserTokenRepository userTokenRepository;
+
+  @Transactional
+  public void saveOrUpdateToken(User user, String provider, String refreshToken,
+      String deviceInfo, LocalDateTime expiresAt) {
+
+    userTokenRepository.findByUserAndProvider(user, provider)
+        .ifPresentOrElse(
+            existingToken -> updateExistingToken(existingToken, refreshToken, deviceInfo, expiresAt),
+            () -> createAndSaveRefreshToken(user, provider, refreshToken, deviceInfo, expiresAt)
+        );
+  }
+
+  private void updateExistingToken(UserToken token, String refreshToken,
+      String deviceInfo, LocalDateTime expiresAt) {
+    token.setRefreshToken(refreshToken);
+    token.setDeviceInfo(deviceInfo);
+    token.setExpiresAt(expiresAt);
+    token.setRevoked(false);
+    token.setUpdatedAt(LocalDateTime.now());
+    userTokenRepository.save(token);
+  }
+
+  private void createAndSaveRefreshToken(User user, String provider, String refreshToken,
+      String deviceInfo, LocalDateTime expiresAt) {
+
+    UserToken newToken = UserToken.builder()
+        .user(user)
+        .provider(provider)
+        .refreshToken(refreshToken)
+        .deviceInfo(deviceInfo)
+        .isRevoked(false)
+        .expiresAt(expiresAt)
+        .createdAt(LocalDateTime.now())
+        .updatedAt(LocalDateTime.now())
+        .build();
+
+    userTokenRepository.save(newToken);
+  }
+}

--- a/src/main/java/kr/ai/nemo/common/exception/ApiResponse.java
+++ b/src/main/java/kr/ai/nemo/common/exception/ApiResponse.java
@@ -15,6 +15,15 @@ public class ApiResponse<T> {
   private int code;
   private String message;
   private T data;
+  private String errorCode;
+
+  // 성공 응답 생성자 (errorCode 필드 추가로 인한 생성자 추가)
+  public ApiResponse(int code, String message, T data) {
+    this.code = code;
+    this.message = message;
+    this.data = data;
+    this.errorCode = null; // 성공 응답에서는 errorCode가 null
+  }
 
   // 성공 응답 (200 OK, 데이터 있음)
   public static <T> ApiResponse<T> success(T data) {
@@ -34,5 +43,25 @@ public class ApiResponse<T> {
   // 오류 응답 (ErrorCode 사용)
   public static <T> ApiResponse<T> error(ResponseCode responseCode) {
     return new ApiResponse<>(responseCode.getHttpStatus().value(), responseCode.getMessage(), null);
+  }
+  
+  // 오류 응답 (메시지와 에러코드 직접 지정)
+  public static <T> ApiResponse<T> error(String message, String errorCode) {
+    return ApiResponse.<T>builder()
+            .code(HttpStatus.BAD_REQUEST.value())
+            .message(message)
+            .data(null)
+            .errorCode(errorCode)
+            .build();
+  }
+  
+  // 오류 응답 (메시지만 직접 지정)
+  public static <T> ApiResponse<T> error(String message) {
+    return ApiResponse.<T>builder()
+            .code(HttpStatus.BAD_REQUEST.value())
+            .message(message)
+            .data(null)
+            .errorCode("ERROR")
+            .build();
   }
 }

--- a/src/main/java/kr/ai/nemo/common/exception/GlobalExceptionHandler.java
+++ b/src/main/java/kr/ai/nemo/common/exception/GlobalExceptionHandler.java
@@ -1,5 +1,6 @@
 package kr.ai.nemo.common.exception;
 
+import kr.ai.nemo.auth.exception.OAuthException;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.http.converter.HttpMessageNotReadableException;
@@ -7,6 +8,7 @@ import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.MissingServletRequestParameterException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
+import org.springframework.web.client.RestClientException;
 
 @RestControllerAdvice
 public class GlobalExceptionHandler {
@@ -38,11 +40,29 @@ public class GlobalExceptionHandler {
         .status(HttpStatus.BAD_REQUEST)
         .body(ApiResponse.error(ResponseCode.INVALID_ENUM));
   }
-  
+
   @ExceptionHandler(Exception.class)
   public ResponseEntity<ApiResponse<?>> handleGeneralException(Exception e) {
     return ResponseEntity
         .status(HttpStatus.INTERNAL_SERVER_ERROR)
         .body(ApiResponse.error(ResponseCode.INTERNAL_SERVER_ERROR));
+  }
+
+  @ExceptionHandler(OAuthException.class)
+  public ResponseEntity<ApiResponse<Object>> handleOAuthException(OAuthException e) {
+    return ResponseEntity.status(HttpStatus.UNAUTHORIZED)
+        .body(ApiResponse.error(e.getMessage()));
+  }
+
+  @ExceptionHandler(RestClientException.class)
+  public ResponseEntity<ApiResponse<Object>> handleRestClientException(RestClientException e) {
+    return ResponseEntity.status(HttpStatus.SERVICE_UNAVAILABLE)
+        .body(ApiResponse.error("외부 API 호출 중 오류가 발생했습니다: " + e.getMessage()));
+  }
+
+  @ExceptionHandler(Exception.class)
+  public ResponseEntity<ApiResponse<Object>> handleException(Exception e) {
+    return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR)
+        .body(ApiResponse.error("서버 내부 오류가 발생했습니다: " + e.getMessage()));
   }
 }

--- a/src/main/java/kr/ai/nemo/config/AppConfig.java
+++ b/src/main/java/kr/ai/nemo/config/AppConfig.java
@@ -1,0 +1,14 @@
+package kr.ai.nemo.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.client.RestTemplate;
+
+@Configuration
+public class AppConfig {
+
+  @Bean
+  public RestTemplate restTemplate() {
+    return new RestTemplate();
+  }
+}

--- a/src/main/java/kr/ai/nemo/user/domain/User.java
+++ b/src/main/java/kr/ai/nemo/user/domain/User.java
@@ -1,5 +1,54 @@
 package kr.ai.nemo.user.domain;
 
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import java.time.LocalDateTime;
+import kr.ai.nemo.user.domain.enums.UserStatus;
+import lombok.*;
+
+@Getter
+@Entity
+@Table(name = "users")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Builder
 public class User {
 
+  @Id
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
+  private Long id;
+
+  @Column(name = "provider", nullable = false)
+  private String provider;
+
+  @Column(name = "provider_id", nullable = false, unique = true)
+  private String providerId;
+
+  @Column(name = "email", nullable = false)
+  private String email;
+
+  @Column(name = "nickname", nullable = false)
+  private String nickname;
+
+  @Column(name = "profile_image_url", nullable = false)
+  private String profileImageUrl;
+
+  @Enumerated(EnumType.STRING)
+  @Column(name = "status", nullable = false)
+  private UserStatus status;
+
+  @Column(name = "created_at", nullable = false, updatable = false)
+  private LocalDateTime createdAt;
+
+  @Column(name = "updated_at", nullable = false)
+  private LocalDateTime updatedAt;
+
+  @Column(name = "deleted_at")
+  private LocalDateTime deletedAt;
 }

--- a/src/main/java/kr/ai/nemo/user/domain/User.java
+++ b/src/main/java/kr/ai/nemo/user/domain/User.java
@@ -1,0 +1,5 @@
+package kr.ai.nemo.user.domain;
+
+public class User {
+
+}

--- a/src/main/java/kr/ai/nemo/user/domain/enums/UserStatus.java
+++ b/src/main/java/kr/ai/nemo/user/domain/enums/UserStatus.java
@@ -1,0 +1,6 @@
+package kr.ai.nemo.user.domain.enums;
+
+public enum UserStatus {
+  ACTIVE, WITHDRAWN
+
+}

--- a/src/main/java/kr/ai/nemo/user/dto/UserDto.java
+++ b/src/main/java/kr/ai/nemo/user/dto/UserDto.java
@@ -1,0 +1,27 @@
+package kr.ai.nemo.user.dto;
+
+import kr.ai.nemo.user.domain.User;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+public class UserDto {
+  private Long userId;
+  private String nickname;
+  private String profileImageUrl;
+  private int cacheTtl;
+
+  public static UserDto from(User user) {
+    return UserDto.builder()
+        .userId(user.getId())
+        .nickname(user.getNickname())
+        .profileImageUrl(user.getProfileImageUrl())
+        .cacheTtl(300)
+        .build();
+  }
+}

--- a/src/main/java/kr/ai/nemo/user/dto/UserLoginResponse.java
+++ b/src/main/java/kr/ai/nemo/user/dto/UserLoginResponse.java
@@ -1,0 +1,18 @@
+package kr.ai.nemo.user.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+public class UserLoginResponse {
+
+  private String accessToken;
+  private String refreshToken;
+  private int refreshTokenExpiresIn;
+  private UserDto user;
+}

--- a/src/main/java/kr/ai/nemo/user/repository/UserRepository.java
+++ b/src/main/java/kr/ai/nemo/user/repository/UserRepository.java
@@ -1,0 +1,10 @@
+package kr.ai.nemo.user.repository;
+
+import java.util.Optional;
+import kr.ai.nemo.user.domain.User;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface UserRepository extends JpaRepository<User, Long> {
+
+  Optional<User> findByProviderAndProviderId(String provider, String providerId);
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -22,3 +22,12 @@ spring:
   messages:
     basename: validation
     encoding: UTF-8
+
+management:
+  endpoints:
+    web:
+      exposure:
+        include: health, info, metrics
+  endpoint:
+    health:
+      show-details: never

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -22,12 +22,3 @@ spring:
   messages:
     basename: validation
     encoding: UTF-8
-
-management:
-  endpoints:
-    web:
-      exposure:
-        include: health, info, metrics
-  endpoint:
-    health:
-      show-details: never

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -17,8 +17,25 @@ spring:
         format_sql: true
     database-platform: org.hibernate.dialect.MySQL8Dialect
 
-
-
   messages:
     basename: validation
     encoding: UTF-8
+
+oauth:
+  kakao:
+    rest-api-key: ${KAKAO_REST_API_KEY}
+    redirect-uri: ${KAKAO_REDIRECT_URI}
+
+jwt:
+  secret: ${JWT_SECRET}
+  access-token-validity: 3600000
+  refresh-token-validity: 1209600000
+
+management:
+  endpoints:
+    web:
+      exposure:
+        include: health, info, metrics
+  endpoint:
+    health:
+      show-details: never


### PR DESCRIPTION
## What
→ 카카오 간편 로그인 API 개발하였습니다.

## Why
→ 사용자가 쉽고 빠르게 서비스에 회원가입/로그인을 할 수 있습니다.

## Changes
→ OauthController에 카카오 콜백 엔드포인트 추가
→ OauthService에서 카카오 인가 코드로 사용자 정보 조회 및 JWT 발급 처리
→ User 테이블에 provider, providerId 기반 사용자 저장 로직 추가
→ 에러 발생 시 OAuthException 및 OAuthErrorCode를 통한 예외처리 적용
→ 기본값 및 로그인 디바이스/프로바이더 관련 Enum 분리


## Related Issue
→ closed #19 