### PR TITLE
feat: 그룹 ID로 모임원 목록 조회 API 개발 (JOINED 상태 기준)

### DIFF
--- a/src/main/java/kr/ai/nemo/config/SecurityConfig.java
+++ b/src/main/java/kr/ai/nemo/config/SecurityConfig.java
@@ -28,7 +28,7 @@ public class SecurityConfig {
         .authorizeHttpRequests(auth -> auth
             .requestMatchers("/auth/**").permitAll()
             .requestMatchers(HttpMethod.GET, "/api/v1/auth/*").permitAll()
-            .requestMatchers(HttpMethod.GET, "/api/v1/groups/*").permitAll()
+            .requestMatchers(HttpMethod.GET, "/api/v1/groups/**").permitAll()
             .requestMatchers("/test/token/**").permitAll()
             .anyRequest().authenticated()
         )

--- a/src/main/java/kr/ai/nemo/group/participants/controller/GroupParticipantsController.java
+++ b/src/main/java/kr/ai/nemo/group/participants/controller/GroupParticipantsController.java
@@ -1,8 +1,12 @@
 package kr.ai.nemo.group.participants.controller;
 
+import java.util.List;
 import kr.ai.nemo.common.exception.ApiResponse;
+import kr.ai.nemo.group.participants.dto.GroupParticipantDto;
+import kr.ai.nemo.group.participants.dto.GroupParticipantsListResponse;
 import kr.ai.nemo.group.participants.service.GroupParticipantsService;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -17,10 +21,10 @@ public class GroupParticipantsController {
   private final GroupParticipantsService groupParticipantsService;
 
   @PostMapping("/groups/{groupId}/applications")
-  public ApiResponse<Void> applyToGroup(@PathVariable Long groupId){
+  public ResponseEntity<Object> applyToGroup(@PathVariable Long groupId){
     Long userId = Long.parseLong(SecurityContextHolder.getContext().getAuthentication().getName());
     groupParticipantsService.applyToGroup(groupId, userId);
-    return ApiResponse.noContent();
+    return ResponseEntity.noContent().build();
   }
 
   @GetMapping("/groups/{groupId}/participants")

--- a/src/main/java/kr/ai/nemo/group/participants/controller/GroupParticipantsController.java
+++ b/src/main/java/kr/ai/nemo/group/participants/controller/GroupParticipantsController.java
@@ -4,6 +4,7 @@ import kr.ai.nemo.common.exception.ApiResponse;
 import kr.ai.nemo.group.participants.service.GroupParticipantsService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -20,5 +21,11 @@ public class GroupParticipantsController {
     Long userId = Long.parseLong(SecurityContextHolder.getContext().getAuthentication().getName());
     groupParticipantsService.applyToGroup(groupId, userId);
     return ApiResponse.noContent();
+  }
+
+  @GetMapping("/groups/{groupId}/participants")
+  public ResponseEntity<ApiResponse<GroupParticipantsListResponse>> getGroupParticipants(@PathVariable Long groupId) {
+    List<GroupParticipantDto> list = groupParticipantsService.getAcceptedParticipants(groupId);
+    return ResponseEntity.ok(ApiResponse.success(new GroupParticipantsListResponse(list)));
   }
 }

--- a/src/main/java/kr/ai/nemo/group/participants/controller/GroupParticipantsController.java
+++ b/src/main/java/kr/ai/nemo/group/participants/controller/GroupParticipantsController.java
@@ -2,6 +2,8 @@ package kr.ai.nemo.group.participants.controller;
 
 import java.util.List;
 import kr.ai.nemo.common.exception.ApiResponse;
+import kr.ai.nemo.group.participants.domain.enums.Role;
+import kr.ai.nemo.group.participants.domain.enums.Status;
 import kr.ai.nemo.group.participants.dto.GroupParticipantDto;
 import kr.ai.nemo.group.participants.dto.GroupParticipantsListResponse;
 import kr.ai.nemo.group.participants.service.GroupParticipantsService;
@@ -23,7 +25,7 @@ public class GroupParticipantsController {
   @PostMapping("/groups/{groupId}/applications")
   public ResponseEntity<Object> applyToGroup(@PathVariable Long groupId){
     Long userId = Long.parseLong(SecurityContextHolder.getContext().getAuthentication().getName());
-    groupParticipantsService.applyToGroup(groupId, userId);
+    groupParticipantsService.applyToGroup(groupId, userId, Role.MEMBER, Status.JOINED);
     return ResponseEntity.noContent().build();
   }
 

--- a/src/main/java/kr/ai/nemo/group/participants/domain/GroupParticipants.java
+++ b/src/main/java/kr/ai/nemo/group/participants/domain/GroupParticipants.java
@@ -2,6 +2,8 @@ package kr.ai.nemo.group.participants.domain;
 
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
 import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
@@ -11,6 +13,7 @@ import jakarta.persistence.ManyToOne;
 import jakarta.persistence.Table;
 import java.time.LocalDateTime;
 import kr.ai.nemo.group.domain.Group;
+import kr.ai.nemo.group.participants.domain.enums.Role;
 import kr.ai.nemo.group.participants.domain.enums.Status;
 import kr.ai.nemo.user.domain.User;
 import lombok.AccessLevel;
@@ -40,12 +43,14 @@ public class GroupParticipants {
   @JoinColumn(name = "group_id", nullable = false)
   private Group group;
 
+  @Enumerated(EnumType.STRING)
   @Column(name = "role", nullable = false)
-  private String role;
+  private Role role;
 
   @Setter
+  @Enumerated(EnumType.STRING)
   @Column(name = "status", nullable = false)
-  private String status;
+  private Status status;
 
   @Column(name = "applied_at", nullable = false)
   private LocalDateTime appliedAt;
@@ -60,11 +65,11 @@ public class GroupParticipants {
 
   public void markAsDeleted() {
     this.deletedAt = LocalDateTime.now();
-    this.status = Status.WITHDRAWN.getDisplayName();
+    this.status = Status.WITHDRAWN;
   }
 
   public void markAsJoined() {
     this.joinedAt = LocalDateTime.now();
-    this.status = Status.JOINED.getDisplayName();
+    this.status = Status.JOINED;
   }
 }

--- a/src/main/java/kr/ai/nemo/group/participants/dto/GroupParticipantDto.java
+++ b/src/main/java/kr/ai/nemo/group/participants/dto/GroupParticipantDto.java
@@ -1,0 +1,18 @@
+package kr.ai.nemo.group.participants.dto;
+
+import kr.ai.nemo.user.domain.User;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class GroupParticipantDto {
+  private Long userId;
+  private String nickname;
+  private String profileImageUrl;
+
+  public static GroupParticipantDto from(User user) {
+    return new GroupParticipantDto(user.getId(), user.getNickname(), user.getProfileImageUrl());
+  }
+
+}

--- a/src/main/java/kr/ai/nemo/group/participants/dto/GroupParticipantsListResponse.java
+++ b/src/main/java/kr/ai/nemo/group/participants/dto/GroupParticipantsListResponse.java
@@ -1,0 +1,11 @@
+package kr.ai.nemo.group.participants.dto;
+
+import java.util.List;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class GroupParticipantsListResponse {
+  private List<GroupParticipantDto> participants;
+}

--- a/src/main/java/kr/ai/nemo/group/participants/repository/GroupParticipantsRepository.java
+++ b/src/main/java/kr/ai/nemo/group/participants/repository/GroupParticipantsRepository.java
@@ -4,9 +4,13 @@ import java.util.List;
 import kr.ai.nemo.group.participants.domain.GroupParticipants;
 import kr.ai.nemo.group.participants.domain.enums.Status;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
 
 @Repository
 public interface GroupParticipantsRepository extends JpaRepository<GroupParticipants, Long> {
   boolean existsByGroupIdAndUserIdAndStatusIn(Long groupId, Long userId, List<Status> pending);
+
+  @Query("SELECT gp FROM GroupParticipants gp JOIN FETCH gp.user WHERE gp.group.id = :groupId AND gp.status = :status")
+  List<GroupParticipants> findByGroupIdAndStatus(Long groupId, Status status);
 }

--- a/src/main/java/kr/ai/nemo/group/participants/service/GroupParticipantsService.java
+++ b/src/main/java/kr/ai/nemo/group/participants/service/GroupParticipantsService.java
@@ -8,6 +8,7 @@ import kr.ai.nemo.group.domain.Group;
 import kr.ai.nemo.group.participants.domain.GroupParticipants;
 import kr.ai.nemo.group.participants.domain.enums.Role;
 import kr.ai.nemo.group.participants.domain.enums.Status;
+import kr.ai.nemo.group.participants.dto.GroupParticipantDto;
 import kr.ai.nemo.group.participants.repository.GroupParticipantsRepository;
 import kr.ai.nemo.group.service.GroupQueryService;
 import kr.ai.nemo.user.service.UserQueryService;
@@ -44,5 +45,15 @@ public class GroupParticipantsService {
     groupParticipantsRepository.save(groupParticipants);
 
     group.addCurrentCount();
+  }
+
+  public List<GroupParticipantDto> getAcceptedParticipants(Long groupId) {
+    groupQueryService.findByIdOrThrow(groupId);
+
+    List<GroupParticipants> participants = groupParticipantsRepository.findByGroupIdAndStatus(groupId, Status.JOINED);
+
+    return participants.stream()
+        .map(p -> GroupParticipantDto.from(p.getUser()))
+        .toList();
   }
 }

--- a/src/main/java/kr/ai/nemo/group/participants/service/GroupParticipantsService.java
+++ b/src/main/java/kr/ai/nemo/group/participants/service/GroupParticipantsService.java
@@ -14,6 +14,7 @@ import kr.ai.nemo.group.service.GroupQueryService;
 import kr.ai.nemo.user.service.UserQueryService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @RequiredArgsConstructor
@@ -23,7 +24,8 @@ public class GroupParticipantsService {
   private final UserQueryService userQueryService;
   private final GroupQueryService groupQueryService;
 
-  public void applyToGroup(Long groupId, Long userId) {
+  @Transactional
+  public void applyToGroup(Long groupId, Long userId, Role role, Status status) {
 
     boolean exists = groupParticipantsRepository.existsByGroupIdAndUserIdAndStatusIn(
         groupId, userId, List.of(Status.PENDING, Status.JOINED));
@@ -34,15 +36,15 @@ public class GroupParticipantsService {
       throw new CustomException(ResponseCode.ALREADY_APPLIED_OR_JOINED);
     }
 
-    GroupParticipants groupParticipants = GroupParticipants.builder()
+    GroupParticipants participant = GroupParticipants.builder()
         .user(userQueryService.findByIdOrThrow(userId))
         .group(group)
-        .role(Role.MEMBER.getDescription())
-        .status(Status.JOINED.getDisplayName())
+        .role(role)
+        .status(status)
         .appliedAt(LocalDateTime.now())
         .build();
 
-    groupParticipantsRepository.save(groupParticipants);
+    groupParticipantsRepository.save(participant);
 
     group.addCurrentCount();
   }

--- a/src/main/java/kr/ai/nemo/group/service/GroupCommandService.java
+++ b/src/main/java/kr/ai/nemo/group/service/GroupCommandService.java
@@ -2,8 +2,6 @@ package kr.ai.nemo.group.service;
 
 import jakarta.validation.Valid;
 import java.util.List;
-import kr.ai.nemo.common.exception.CustomException;
-import kr.ai.nemo.common.exception.ResponseCode;
 import kr.ai.nemo.group.domain.Group;
 import kr.ai.nemo.group.domain.enums.GroupStatus;
 import kr.ai.nemo.group.domain.GroupTag;
@@ -13,7 +11,6 @@ import kr.ai.nemo.group.dto.GroupCreateResponse;
 import kr.ai.nemo.group.repository.GroupRepository;
 import kr.ai.nemo.group.repository.GroupTagRepository;
 import kr.ai.nemo.group.repository.TagRepository;
-import kr.ai.nemo.user.repository.UserRepository;
 import kr.ai.nemo.user.service.UserQueryService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;

--- a/src/main/java/kr/ai/nemo/group/service/GroupQueryService.java
+++ b/src/main/java/kr/ai/nemo/group/service/GroupQueryService.java
@@ -10,7 +10,6 @@ import kr.ai.nemo.group.dto.GroupDto;
 import kr.ai.nemo.group.dto.GroupListResponse;
 import kr.ai.nemo.group.dto.GroupSearchRequest;
 import kr.ai.nemo.group.repository.GroupRepository;
-import kr.ai.nemo.user.domain.User;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.Page;
@@ -42,9 +41,6 @@ public class GroupQueryService {
     } else {
       groups = groupRepository.findAll(pageable);
     }
-
-
-
 
     List<GroupDto> groupDto = groups.getContent().stream()
         .map(GroupDto::from)


### PR DESCRIPTION
## What
→ 모임 ID 기준 모임원 조회 API를 구현했습니다.

## Why
→ 모임 상세 페이지에서 현재 참여 중인 멤버 목록을 보여주기 위해 필요했습니다.

## Changes
→ GET /api/v1/groups/{groupId}/participants 엔드포인트 추가
→ GroupParticipantsService에 getAcceptedParticipants 메서드 구현
→ 참여 상태가 JOINED인 사용자만 필터링하여 반환
→ 응답 DTO: GroupParticipantDto, GroupParticipantsListResponse 정의

## Related Issue
#29 #31 