### PR TITLE
feat: 나의 모임 list 조회 API 구현

### DIFF
--- a/src/main/java/kr/ai/nemo/config/SecurityConfig.java
+++ b/src/main/java/kr/ai/nemo/config/SecurityConfig.java
@@ -28,6 +28,7 @@ public class SecurityConfig {
         .authorizeHttpRequests(auth -> auth
             .requestMatchers("/auth/**").permitAll()
             .requestMatchers(HttpMethod.GET, "/api/v1/auth/*").permitAll()
+            .requestMatchers(HttpMethod.GET, "/api/v1/groups/me").authenticated()
             .requestMatchers(HttpMethod.GET, "/api/v1/groups/**").permitAll()
             .requestMatchers("/test/token/**").permitAll()
             .anyRequest().authenticated()

--- a/src/main/java/kr/ai/nemo/group/participants/controller/GroupParticipantsController.java
+++ b/src/main/java/kr/ai/nemo/group/participants/controller/GroupParticipantsController.java
@@ -6,6 +6,7 @@ import kr.ai.nemo.group.participants.domain.enums.Role;
 import kr.ai.nemo.group.participants.domain.enums.Status;
 import kr.ai.nemo.group.participants.dto.GroupParticipantDto;
 import kr.ai.nemo.group.participants.dto.GroupParticipantsListResponse;
+import kr.ai.nemo.group.participants.dto.MyGroupDto;
 import kr.ai.nemo.group.participants.service.GroupParticipantsService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;

--- a/src/main/java/kr/ai/nemo/group/participants/controller/GroupParticipantsController.java
+++ b/src/main/java/kr/ai/nemo/group/participants/controller/GroupParticipantsController.java
@@ -7,6 +7,7 @@ import kr.ai.nemo.group.participants.domain.enums.Status;
 import kr.ai.nemo.group.participants.dto.GroupParticipantDto;
 import kr.ai.nemo.group.participants.dto.GroupParticipantsListResponse;
 import kr.ai.nemo.group.participants.dto.MyGroupDto;
+import kr.ai.nemo.group.participants.dto.MyGroupListResponse;
 import kr.ai.nemo.group.participants.service.GroupParticipantsService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
@@ -40,6 +41,6 @@ public class GroupParticipantsController {
   public ResponseEntity<ApiResponse<MyGroupListResponse>> getMyGroups() {
     Long userId = Long.parseLong(SecurityContextHolder.getContext().getAuthentication().getName());
     List<MyGroupDto> groupList = groupParticipantsService.getMyGroups(userId);
-    return ResponseEntity.ok(ApiResponse.success(new MyGroupListResponse(groupList)))
+    return ResponseEntity.ok(ApiResponse.success(new MyGroupListResponse(groupList)));
   }
 }

--- a/src/main/java/kr/ai/nemo/group/participants/controller/GroupParticipantsController.java
+++ b/src/main/java/kr/ai/nemo/group/participants/controller/GroupParticipantsController.java
@@ -34,4 +34,11 @@ public class GroupParticipantsController {
     List<GroupParticipantDto> list = groupParticipantsService.getAcceptedParticipants(groupId);
     return ResponseEntity.ok(ApiResponse.success(new GroupParticipantsListResponse(list)));
   }
+
+  @GetMapping("/groups/me")
+  public ResponseEntity<ApiResponse<MyGroupListResponse>> getMyGroups() {
+    Long userId = Long.parseLong(SecurityContextHolder.getContext().getAuthentication().getName());
+    List<MyGroupDto> groupList = groupParticipantsService.getMyGroups(userId);
+    return ResponseEntity.ok(ApiResponse.success(new MyGroupListResponse(groupList)))
+  }
 }

--- a/src/main/java/kr/ai/nemo/group/participants/dto/MyGroupDto.java
+++ b/src/main/java/kr/ai/nemo/group/participants/dto/MyGroupDto.java
@@ -1,0 +1,34 @@
+package kr.ai.nemo.group.participants.dto;
+
+import java.util.List;
+import kr.ai.nemo.group.domain.Group;
+import kr.ai.nemo.group.domain.enums.Category;
+
+public record MyGroupDto(
+    Long id,
+    String name,
+    String summary,
+    String location,
+    String imageUrl,
+    int currentUserCount,
+    int maxUserCount,
+    String category,
+    List<String> tags
+) {
+  public static MyGroupDto from(Group group) {
+    return new MyGroupDto(
+        group.getId(),
+        group.getName(),
+        group.getSummary(),
+        group.getLocation(),
+        group.getImageUrl(),
+        group.getCurrentUserCount(),
+        group.getMaxUserCount(),
+        Category.toDisplayName(group.getCategory()),
+        group.getGroupTags().stream()
+            .map(gt -> gt.getTag().getName())
+            .toList()
+    );
+  }
+}
+

--- a/src/main/java/kr/ai/nemo/group/participants/dto/MyGroupListResponse.java
+++ b/src/main/java/kr/ai/nemo/group/participants/dto/MyGroupListResponse.java
@@ -1,0 +1,7 @@
+package kr.ai.nemo.group.participants.dto;
+
+import java.util.List;
+
+public record MyGroupListResponse(
+    List<MyGroupDto> groups
+) {}

--- a/src/main/java/kr/ai/nemo/group/participants/repository/GroupParticipantsRepository.java
+++ b/src/main/java/kr/ai/nemo/group/participants/repository/GroupParticipantsRepository.java
@@ -13,4 +13,14 @@ public interface GroupParticipantsRepository extends JpaRepository<GroupParticip
 
   @Query("SELECT gp FROM GroupParticipants gp JOIN FETCH gp.user WHERE gp.group.id = :groupId AND gp.status = :status")
   List<GroupParticipants> findByGroupIdAndStatus(Long groupId, Status status);
+
+  @Query("""
+  SELECT gp FROM GroupParticipants gp
+  JOIN FETCH gp.group g
+  LEFT JOIN FETCH g.groupTags gt
+  LEFT JOIN FETCH gt.tag
+  WHERE gp.user.id = :userId
+    AND gp.status = :status
+""")
+  List<GroupParticipants> findByUserIdAndStatus(Long userId, Status status);
 }

--- a/src/main/java/kr/ai/nemo/group/participants/service/GroupParticipantsService.java
+++ b/src/main/java/kr/ai/nemo/group/participants/service/GroupParticipantsService.java
@@ -9,6 +9,7 @@ import kr.ai.nemo.group.participants.domain.GroupParticipants;
 import kr.ai.nemo.group.participants.domain.enums.Role;
 import kr.ai.nemo.group.participants.domain.enums.Status;
 import kr.ai.nemo.group.participants.dto.GroupParticipantDto;
+import kr.ai.nemo.group.participants.dto.MyGroupDto;
 import kr.ai.nemo.group.participants.repository.GroupParticipantsRepository;
 import kr.ai.nemo.group.service.GroupQueryService;
 import kr.ai.nemo.user.service.UserQueryService;
@@ -26,7 +27,6 @@ public class GroupParticipantsService {
 
   @Transactional
   public void applyToGroup(Long groupId, Long userId, Role role, Status status) {
-
     boolean exists = groupParticipantsRepository.existsByGroupIdAndUserIdAndStatusIn(
         groupId, userId, List.of(Status.PENDING, Status.JOINED));
 
@@ -45,17 +45,21 @@ public class GroupParticipantsService {
         .build();
 
     groupParticipantsRepository.save(participant);
-
     group.addCurrentCount();
   }
 
   public List<GroupParticipantDto> getAcceptedParticipants(Long groupId) {
     groupQueryService.findByIdOrThrow(groupId);
-
     List<GroupParticipants> participants = groupParticipantsRepository.findByGroupIdAndStatus(groupId, Status.JOINED);
-
     return participants.stream()
         .map(p -> GroupParticipantDto.from(p.getUser()))
+        .toList();
+  }
+
+  public List<MyGroupDto> getMyGroups(Long userId) {
+    List<GroupParticipants> participants = groupParticipantsRepository.findByUserIdAndStatus(userId, Status.JOINED);
+    return participants.stream()
+        .map(p -> MyGroupDto.from(p.getGroup()))
         .toList();
   }
 }


### PR DESCRIPTION
## What
→ 나의 모임 list 조회 API를 구현했습니다.

## Why
→ 사용자가 본인이 참여 중인 모임을 확인할 수 있도록 하기 위함입니다.

## Changes
→ GET /api/v1/groups/me API 엔드포인트 추가
→ GroupParticipantsService에 getMyGroups(userId) 로직 추가
→ MyGroupDto, MyGroupListResponse DTO 설계 및 적용
→ Security 설정에서 /groups/me 경로는 인증 필요하도록 수정

## Related Issue
#29 #30 

