### PR TITLE
feat: Group-Participants 도메인 개발

### DIFF
--- a/src/main/java/kr/ai/nemo/common/exception/ResponseCode.java
+++ b/src/main/java/kr/ai/nemo/common/exception/ResponseCode.java
@@ -29,6 +29,9 @@ public enum ResponseCode {
   USER_NOT_FOUND("USER_NOT_FOUND", "사용자를 찾을 수 없습니다.", HttpStatus.NOT_FOUND),
   GROUP_NOT_FOUND("GROUP_NOT_FOUND", "모임을 찾을 수 없습니다.", HttpStatus.NOT_FOUND),
 
+  // 409 Conflict
+  ALREADY_APPLIED_OR_JOINED("ALREADY_APPLIED_OR_JOINED", "이미 신청했거나 참여 중인 사용자입니다.", HttpStatus.CONFLICT),
+
   // 500 INTERNAL SERVER ERROR
   INTERNAL_SERVER_ERROR("INTERNAL_SERVER_ERROR", "서버 오류가 발생했습니다.", HttpStatus.INTERNAL_SERVER_ERROR),
   AI_SERVER_CONNECTION_FAILED("AI_SERVER_CONNECTION_FAILED", "AI 서버 연결에 실패했습니다.", HttpStatus.INTERNAL_SERVER_ERROR),

--- a/src/main/java/kr/ai/nemo/config/SecurityConfig.java
+++ b/src/main/java/kr/ai/nemo/config/SecurityConfig.java
@@ -28,7 +28,7 @@ public class SecurityConfig {
         .authorizeHttpRequests(auth -> auth
             .requestMatchers("/auth/**").permitAll()
             .requestMatchers(HttpMethod.GET, "/api/v1/auth/*").permitAll()
-            .requestMatchers(HttpMethod.GET, "/api/v1/groups/*").permitAll()
+            .requestMatchers(HttpMethod.GET, "/api/v1/groups/**").permitAll()
             .requestMatchers("/test/token/**").permitAll()
             .anyRequest().authenticated()
         )

--- a/src/main/java/kr/ai/nemo/config/SecurityConfig.java
+++ b/src/main/java/kr/ai/nemo/config/SecurityConfig.java
@@ -28,6 +28,7 @@ public class SecurityConfig {
         .authorizeHttpRequests(auth -> auth
             .requestMatchers("/auth/**").permitAll()
             .requestMatchers(HttpMethod.GET, "/api/v1/auth/*").permitAll()
+            .requestMatchers(HttpMethod.GET, "/api/v1/groups/me").authenticated()
             .requestMatchers(HttpMethod.GET, "/api/v1/groups/**").permitAll()
             .requestMatchers("/test/token/**").permitAll()
             .anyRequest().authenticated()

--- a/src/main/java/kr/ai/nemo/group/domain/Group.java
+++ b/src/main/java/kr/ai/nemo/group/domain/Group.java
@@ -3,11 +3,13 @@ package kr.ai.nemo.group.domain;
 import jakarta.persistence.*;
 import kr.ai.nemo.group.domain.enums.Category;
 import kr.ai.nemo.group.domain.enums.GroupStatus;
+import kr.ai.nemo.group.participants.domain.GroupParticipants;
 import kr.ai.nemo.user.domain.User;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import lombok.Setter;
 import org.springframework.data.annotation.CreatedDate;
 import org.springframework.data.annotation.LastModifiedDate;
 import org.springframework.data.jpa.domain.support.AuditingEntityListener;
@@ -51,24 +53,32 @@ public class Group {
   @Column(name = "location", nullable = false)
   private String location;
 
+  @Setter
   @Column(name = "image_url")
   private String imageUrl;
 
+  @Setter
   @Column(name = "completed_schedule_total", nullable = false)
   private int completedScheduleTotal;
 
+  @Setter
   @Column(name = "current_user_count", nullable = false)
   private int currentUserCount;
 
+  @Setter
   @Column(name = "max_user_count", nullable = false)
   private int maxUserCount;
 
+  @Setter
   @Column(name = "status", nullable = false)
   @Enumerated(EnumType.STRING)
   private GroupStatus status;
 
   @OneToMany(mappedBy = "group", cascade = CascadeType.ALL, orphanRemoval = true)
   private final List<GroupTag> groupTags = new ArrayList<>();
+
+  @OneToMany(mappedBy = "group", cascade = CascadeType.ALL, orphanRemoval = true, fetch = FetchType.LAZY)
+  private final List<GroupParticipants> groupParticipants = new ArrayList<>();
 
   @CreatedDate
   @Column(name = "created_at", updatable = false)
@@ -78,6 +88,7 @@ public class Group {
   @Column(name = "updated_at")
   private LocalDateTime updatedAt;
 
+  @Setter
   @Column(name = "deleted_at")
   private LocalDateTime deletedAt;
 
@@ -107,4 +118,7 @@ public class Group {
     return Category.toDisplayName(this.category);
   }
 
+  public void addCurrentCount() {
+    this.currentUserCount++;
+  }
 }

--- a/src/main/java/kr/ai/nemo/group/participants/controller/GroupParticipantsController.java
+++ b/src/main/java/kr/ai/nemo/group/participants/controller/GroupParticipantsController.java
@@ -1,9 +1,16 @@
 package kr.ai.nemo.group.participants.controller;
 
+import java.util.List;
 import kr.ai.nemo.common.exception.ApiResponse;
+import kr.ai.nemo.group.participants.domain.enums.Role;
+import kr.ai.nemo.group.participants.domain.enums.Status;
+import kr.ai.nemo.group.participants.dto.GroupParticipantDto;
+import kr.ai.nemo.group.participants.dto.GroupParticipantsListResponse;
 import kr.ai.nemo.group.participants.service.GroupParticipantsService;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -16,9 +23,15 @@ public class GroupParticipantsController {
   private final GroupParticipantsService groupParticipantsService;
 
   @PostMapping("/groups/{groupId}/applications")
-  public ApiResponse<Void> applyToGroup(@PathVariable Long groupId){
+  public ResponseEntity<Object> applyToGroup(@PathVariable Long groupId){
     Long userId = Long.parseLong(SecurityContextHolder.getContext().getAuthentication().getName());
-    groupParticipantsService.applyToGroup(groupId, userId);
-    return ApiResponse.noContent();
+    groupParticipantsService.applyToGroup(groupId, userId, Role.MEMBER, Status.JOINED);
+    return ResponseEntity.noContent().build();
+  }
+
+  @GetMapping("/groups/{groupId}/participants")
+  public ResponseEntity<ApiResponse<GroupParticipantsListResponse>> getGroupParticipants(@PathVariable Long groupId) {
+    List<GroupParticipantDto> list = groupParticipantsService.getAcceptedParticipants(groupId);
+    return ResponseEntity.ok(ApiResponse.success(new GroupParticipantsListResponse(list)));
   }
 }

--- a/src/main/java/kr/ai/nemo/group/participants/controller/GroupParticipantsController.java
+++ b/src/main/java/kr/ai/nemo/group/participants/controller/GroupParticipantsController.java
@@ -1,0 +1,24 @@
+package kr.ai.nemo.group.participants.controller;
+
+import kr.ai.nemo.common.exception.ApiResponse;
+import kr.ai.nemo.group.participants.service.GroupParticipantsService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/v1")
+@RequiredArgsConstructor
+public class GroupParticipantsController {
+  private final GroupParticipantsService groupParticipantsService;
+
+  @PostMapping("/groups/{groupId}/applications")
+  public ApiResponse<Void> applyToGroup(@PathVariable Long groupId){
+    Long userId = Long.parseLong(SecurityContextHolder.getContext().getAuthentication().getName());
+    groupParticipantsService.applyToGroup(groupId, userId);
+    return ApiResponse.noContent();
+  }
+}

--- a/src/main/java/kr/ai/nemo/group/participants/controller/GroupParticipantsController.java
+++ b/src/main/java/kr/ai/nemo/group/participants/controller/GroupParticipantsController.java
@@ -6,6 +6,8 @@ import kr.ai.nemo.group.participants.domain.enums.Role;
 import kr.ai.nemo.group.participants.domain.enums.Status;
 import kr.ai.nemo.group.participants.dto.GroupParticipantDto;
 import kr.ai.nemo.group.participants.dto.GroupParticipantsListResponse;
+import kr.ai.nemo.group.participants.dto.MyGroupDto;
+import kr.ai.nemo.group.participants.dto.MyGroupListResponse;
 import kr.ai.nemo.group.participants.service.GroupParticipantsService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
@@ -33,5 +35,12 @@ public class GroupParticipantsController {
   public ResponseEntity<ApiResponse<GroupParticipantsListResponse>> getGroupParticipants(@PathVariable Long groupId) {
     List<GroupParticipantDto> list = groupParticipantsService.getAcceptedParticipants(groupId);
     return ResponseEntity.ok(ApiResponse.success(new GroupParticipantsListResponse(list)));
+  }
+
+  @GetMapping("/groups/me")
+  public ResponseEntity<ApiResponse<MyGroupListResponse>> getMyGroups() {
+    Long userId = Long.parseLong(SecurityContextHolder.getContext().getAuthentication().getName());
+    List<MyGroupDto> groupList = groupParticipantsService.getMyGroups(userId);
+    return ResponseEntity.ok(ApiResponse.success(new MyGroupListResponse(groupList)));
   }
 }

--- a/src/main/java/kr/ai/nemo/group/participants/domain/GroupParticipants.java
+++ b/src/main/java/kr/ai/nemo/group/participants/domain/GroupParticipants.java
@@ -1,0 +1,70 @@
+package kr.ai.nemo.group.participants.domain;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import java.time.LocalDateTime;
+import kr.ai.nemo.group.domain.Group;
+import kr.ai.nemo.group.participants.domain.enums.Status;
+import kr.ai.nemo.user.domain.User;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Entity
+@Getter
+@Table(name = "group_participants")
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class GroupParticipants {
+
+  @Id
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
+  private Long id;
+
+  @ManyToOne(fetch = FetchType.LAZY)
+  @JoinColumn(name = "user_id", nullable = false)
+  private User user;
+
+  @ManyToOne(fetch = FetchType.LAZY)
+  @JoinColumn(name = "group_id", nullable = false)
+  private Group group;
+
+  @Column(name = "role", nullable = false)
+  private String role;
+
+  @Setter
+  @Column(name = "status", nullable = false)
+  private String status;
+
+  @Column(name = "applied_at", nullable = false)
+  private LocalDateTime appliedAt;
+
+  @Setter
+  @Column(name = "joined_at")
+  private LocalDateTime joinedAt;
+
+  @Setter
+  @Column(name = "deleted_at")
+  private LocalDateTime deletedAt;
+
+  public void markAsDeleted() {
+    this.deletedAt = LocalDateTime.now();
+    this.status = Status.WITHDRAWN.getDisplayName();
+  }
+
+  public void markAsJoined() {
+    this.joinedAt = LocalDateTime.now();
+    this.status = Status.JOINED.getDisplayName();
+  }
+}

--- a/src/main/java/kr/ai/nemo/group/participants/domain/GroupParticipants.java
+++ b/src/main/java/kr/ai/nemo/group/participants/domain/GroupParticipants.java
@@ -2,6 +2,8 @@ package kr.ai.nemo.group.participants.domain;
 
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
 import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
@@ -11,6 +13,7 @@ import jakarta.persistence.ManyToOne;
 import jakarta.persistence.Table;
 import java.time.LocalDateTime;
 import kr.ai.nemo.group.domain.Group;
+import kr.ai.nemo.group.participants.domain.enums.Role;
 import kr.ai.nemo.group.participants.domain.enums.Status;
 import kr.ai.nemo.user.domain.User;
 import lombok.AccessLevel;
@@ -40,12 +43,14 @@ public class GroupParticipants {
   @JoinColumn(name = "group_id", nullable = false)
   private Group group;
 
+  @Enumerated(EnumType.STRING)
   @Column(name = "role", nullable = false)
-  private String role;
+  private Role role;
 
   @Setter
+  @Enumerated(EnumType.STRING)
   @Column(name = "status", nullable = false)
-  private String status;
+  private Status status;
 
   @Column(name = "applied_at", nullable = false)
   private LocalDateTime appliedAt;
@@ -60,11 +65,11 @@ public class GroupParticipants {
 
   public void markAsDeleted() {
     this.deletedAt = LocalDateTime.now();
-    this.status = Status.WITHDRAWN.getDisplayName();
+    this.status = Status.WITHDRAWN;
   }
 
   public void markAsJoined() {
     this.joinedAt = LocalDateTime.now();
-    this.status = Status.JOINED.getDisplayName();
+    this.status = Status.JOINED;
   }
 }

--- a/src/main/java/kr/ai/nemo/group/participants/domain/enums/Role.java
+++ b/src/main/java/kr/ai/nemo/group/participants/domain/enums/Role.java
@@ -1,0 +1,13 @@
+package kr.ai.nemo.group.participants.domain.enums;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+@Getter
+public enum Role {
+  LEADER("모임장"),
+  MEMBER("모임원");
+
+  private final String description;
+}

--- a/src/main/java/kr/ai/nemo/group/participants/domain/enums/Status.java
+++ b/src/main/java/kr/ai/nemo/group/participants/domain/enums/Status.java
@@ -1,0 +1,16 @@
+package kr.ai.nemo.group.participants.domain.enums;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+@Getter
+public enum Status {
+  PENDING("신청중"),
+  JOINED("가입중"),
+  KICKED("추방됨"),
+  WITHDRAWN("탈퇴"),
+  REJECTED("거절됨");
+
+  private final String displayName;
+}

--- a/src/main/java/kr/ai/nemo/group/participants/dto/GroupParticipantDto.java
+++ b/src/main/java/kr/ai/nemo/group/participants/dto/GroupParticipantDto.java
@@ -1,0 +1,18 @@
+package kr.ai.nemo.group.participants.dto;
+
+import kr.ai.nemo.user.domain.User;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class GroupParticipantDto {
+  private Long userId;
+  private String nickname;
+  private String profileImageUrl;
+
+  public static GroupParticipantDto from(User user) {
+    return new GroupParticipantDto(user.getId(), user.getNickname(), user.getProfileImageUrl());
+  }
+
+}

--- a/src/main/java/kr/ai/nemo/group/participants/dto/GroupParticipantsListResponse.java
+++ b/src/main/java/kr/ai/nemo/group/participants/dto/GroupParticipantsListResponse.java
@@ -1,0 +1,11 @@
+package kr.ai.nemo.group.participants.dto;
+
+import java.util.List;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class GroupParticipantsListResponse {
+  private List<GroupParticipantDto> participants;
+}

--- a/src/main/java/kr/ai/nemo/group/participants/dto/MyGroupDto.java
+++ b/src/main/java/kr/ai/nemo/group/participants/dto/MyGroupDto.java
@@ -1,0 +1,34 @@
+package kr.ai.nemo.group.participants.dto;
+
+import java.util.List;
+import kr.ai.nemo.group.domain.Group;
+import kr.ai.nemo.group.domain.enums.Category;
+
+public record MyGroupDto(
+    Long id,
+    String name,
+    String summary,
+    String location,
+    String imageUrl,
+    int currentUserCount,
+    int maxUserCount,
+    String category,
+    List<String> tags
+) {
+  public static MyGroupDto from(Group group) {
+    return new MyGroupDto(
+        group.getId(),
+        group.getName(),
+        group.getSummary(),
+        group.getLocation(),
+        group.getImageUrl(),
+        group.getCurrentUserCount(),
+        group.getMaxUserCount(),
+        Category.toDisplayName(group.getCategory()),
+        group.getGroupTags().stream()
+            .map(gt -> gt.getTag().getName())
+            .toList()
+    );
+  }
+}
+

--- a/src/main/java/kr/ai/nemo/group/participants/dto/MyGroupListResponse.java
+++ b/src/main/java/kr/ai/nemo/group/participants/dto/MyGroupListResponse.java
@@ -1,0 +1,7 @@
+package kr.ai.nemo.group.participants.dto;
+
+import java.util.List;
+
+public record MyGroupListResponse(
+    List<MyGroupDto> groups
+) {}

--- a/src/main/java/kr/ai/nemo/group/participants/repository/GroupParticipantsRepository.java
+++ b/src/main/java/kr/ai/nemo/group/participants/repository/GroupParticipantsRepository.java
@@ -1,0 +1,12 @@
+package kr.ai.nemo.group.participants.repository;
+
+import java.util.List;
+import kr.ai.nemo.group.participants.domain.GroupParticipants;
+import kr.ai.nemo.group.participants.domain.enums.Status;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface GroupParticipantsRepository extends JpaRepository<GroupParticipants, Long> {
+  boolean existsByGroupIdAndUserIdAndStatusIn(Long groupId, Long userId, List<Status> pending);
+}

--- a/src/main/java/kr/ai/nemo/group/participants/repository/GroupParticipantsRepository.java
+++ b/src/main/java/kr/ai/nemo/group/participants/repository/GroupParticipantsRepository.java
@@ -4,9 +4,13 @@ import java.util.List;
 import kr.ai.nemo.group.participants.domain.GroupParticipants;
 import kr.ai.nemo.group.participants.domain.enums.Status;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
 
 @Repository
 public interface GroupParticipantsRepository extends JpaRepository<GroupParticipants, Long> {
   boolean existsByGroupIdAndUserIdAndStatusIn(Long groupId, Long userId, List<Status> pending);
+
+  @Query("SELECT gp FROM GroupParticipants gp JOIN FETCH gp.user WHERE gp.group.id = :groupId AND gp.status = :status")
+  List<GroupParticipants> findByGroupIdAndStatus(Long groupId, Status status);
 }

--- a/src/main/java/kr/ai/nemo/group/participants/repository/GroupParticipantsRepository.java
+++ b/src/main/java/kr/ai/nemo/group/participants/repository/GroupParticipantsRepository.java
@@ -13,4 +13,14 @@ public interface GroupParticipantsRepository extends JpaRepository<GroupParticip
 
   @Query("SELECT gp FROM GroupParticipants gp JOIN FETCH gp.user WHERE gp.group.id = :groupId AND gp.status = :status")
   List<GroupParticipants> findByGroupIdAndStatus(Long groupId, Status status);
+
+  @Query("""
+  SELECT gp FROM GroupParticipants gp
+  JOIN FETCH gp.group g
+  LEFT JOIN FETCH g.groupTags gt
+  LEFT JOIN FETCH gt.tag
+  WHERE gp.user.id = :userId
+    AND gp.status = :status
+""")
+  List<GroupParticipants> findByUserIdAndStatus(Long userId, Status status);
 }

--- a/src/main/java/kr/ai/nemo/group/participants/service/GroupParticipantsService.java
+++ b/src/main/java/kr/ai/nemo/group/participants/service/GroupParticipantsService.java
@@ -9,6 +9,7 @@ import kr.ai.nemo.group.participants.domain.GroupParticipants;
 import kr.ai.nemo.group.participants.domain.enums.Role;
 import kr.ai.nemo.group.participants.domain.enums.Status;
 import kr.ai.nemo.group.participants.dto.GroupParticipantDto;
+import kr.ai.nemo.group.participants.dto.MyGroupDto;
 import kr.ai.nemo.group.participants.repository.GroupParticipantsRepository;
 import kr.ai.nemo.group.service.GroupQueryService;
 import kr.ai.nemo.user.service.UserQueryService;
@@ -26,7 +27,6 @@ public class GroupParticipantsService {
 
   @Transactional
   public void applyToGroup(Long groupId, Long userId, Role role, Status status) {
-
     boolean exists = groupParticipantsRepository.existsByGroupIdAndUserIdAndStatusIn(
         groupId, userId, List.of(Status.PENDING, Status.JOINED));
 
@@ -45,17 +45,21 @@ public class GroupParticipantsService {
         .build();
 
     groupParticipantsRepository.save(participant);
-
     group.addCurrentCount();
   }
 
   public List<GroupParticipantDto> getAcceptedParticipants(Long groupId) {
     groupQueryService.findByIdOrThrow(groupId);
-
     List<GroupParticipants> participants = groupParticipantsRepository.findByGroupIdAndStatus(groupId, Status.JOINED);
-
     return participants.stream()
         .map(p -> GroupParticipantDto.from(p.getUser()))
+        .toList();
+  }
+
+  public List<MyGroupDto> getMyGroups(Long userId) {
+    List<GroupParticipants> participants = groupParticipantsRepository.findByUserIdAndStatus(userId, Status.JOINED);
+    return participants.stream()
+        .map(p -> MyGroupDto.from(p.getGroup()))
         .toList();
   }
 }

--- a/src/main/java/kr/ai/nemo/group/participants/service/GroupParticipantsService.java
+++ b/src/main/java/kr/ai/nemo/group/participants/service/GroupParticipantsService.java
@@ -1,0 +1,48 @@
+package kr.ai.nemo.group.participants.service;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import kr.ai.nemo.common.exception.CustomException;
+import kr.ai.nemo.common.exception.ResponseCode;
+import kr.ai.nemo.group.domain.Group;
+import kr.ai.nemo.group.participants.domain.GroupParticipants;
+import kr.ai.nemo.group.participants.domain.enums.Role;
+import kr.ai.nemo.group.participants.domain.enums.Status;
+import kr.ai.nemo.group.participants.repository.GroupParticipantsRepository;
+import kr.ai.nemo.group.service.GroupQueryService;
+import kr.ai.nemo.user.service.UserQueryService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class GroupParticipantsService {
+
+  private final GroupParticipantsRepository groupParticipantsRepository;
+  private final UserQueryService userQueryService;
+  private final GroupQueryService groupQueryService;
+
+  public void applyToGroup(Long groupId, Long userId) {
+
+    boolean exists = groupParticipantsRepository.existsByGroupIdAndUserIdAndStatusIn(
+        groupId, userId, List.of(Status.PENDING, Status.JOINED));
+
+    Group group = groupQueryService.findByIdOrThrow(groupId);
+
+    if (exists) {
+      throw new CustomException(ResponseCode.ALREADY_APPLIED_OR_JOINED);
+    }
+
+    GroupParticipants groupParticipants = GroupParticipants.builder()
+        .user(userQueryService.findByIdOrThrow(userId))
+        .group(group)
+        .role(Role.MEMBER.getDescription())
+        .status(Status.JOINED.getDisplayName())
+        .appliedAt(LocalDateTime.now())
+        .build();
+
+    groupParticipantsRepository.save(groupParticipants);
+
+    group.addCurrentCount();
+  }
+}

--- a/src/main/java/kr/ai/nemo/group/repository/GroupRepository.java
+++ b/src/main/java/kr/ai/nemo/group/repository/GroupRepository.java
@@ -15,4 +15,6 @@ public interface GroupRepository extends JpaRepository<Group, Long> {
   Page<Group> searchWithKeywordOnly(@Param("keyword") String keyword, Pageable pageable);
 
   Page<Group> findByCategory(Category categoryEnum, Pageable pageable);
+
+  Group getGroupById(Long id);
 }

--- a/src/main/java/kr/ai/nemo/group/service/GroupCommandService.java
+++ b/src/main/java/kr/ai/nemo/group/service/GroupCommandService.java
@@ -1,19 +1,17 @@
 package kr.ai.nemo.group.service;
 
 import jakarta.validation.Valid;
-import java.util.List;
-import kr.ai.nemo.common.exception.CustomException;
-import kr.ai.nemo.common.exception.ResponseCode;
+import java.time.LocalDateTime;
 import kr.ai.nemo.group.domain.Group;
 import kr.ai.nemo.group.domain.enums.GroupStatus;
-import kr.ai.nemo.group.domain.GroupTag;
-import kr.ai.nemo.group.domain.Tag;
 import kr.ai.nemo.group.dto.GroupCreateRequest;
 import kr.ai.nemo.group.dto.GroupCreateResponse;
+import kr.ai.nemo.group.participants.domain.GroupParticipants;
+import kr.ai.nemo.group.participants.domain.enums.Role;
+import kr.ai.nemo.group.participants.domain.enums.Status;
+import kr.ai.nemo.group.participants.repository.GroupParticipantsRepository;
 import kr.ai.nemo.group.repository.GroupRepository;
-import kr.ai.nemo.group.repository.GroupTagRepository;
-import kr.ai.nemo.group.repository.TagRepository;
-import kr.ai.nemo.user.repository.UserRepository;
+import kr.ai.nemo.user.domain.User;
 import kr.ai.nemo.user.service.UserQueryService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -24,15 +22,17 @@ import org.springframework.transaction.annotation.Transactional;
 public class GroupCommandService {
 
   private final GroupRepository groupRepository;
-  private final TagRepository tagRepository;
-  private final GroupTagRepository groupTagRepository;
+  private final GroupTagService groupTagService;
   private final UserQueryService userQueryService;
+  private final GroupParticipantsRepository groupParticipantsRepository;
 
   @Transactional
   public GroupCreateResponse createGroup(@Valid GroupCreateRequest request, Long userId) {
 
+    User user = userQueryService.findByIdOrThrow(userId);
+
     Group group = Group.builder()
-        .owner(userQueryService.findByIdOrThrow(userId))
+        .owner(user)
         .name(request.getName())
         .summary(request.getSummary())
         .description(request.getDescription())
@@ -50,29 +50,20 @@ public class GroupCommandService {
     Group savedGroup = groupRepository.save(group);
 
     if (request.getTags() != null && !request.getTags().isEmpty()) {
-      processTags(savedGroup, request.getTags());
+      groupTagService.assignTags(savedGroup, request.getTags());
     }
+
+    GroupParticipants participants = GroupParticipants.builder()
+        .user(user)
+        .group(group)
+        .role(Role.LEADER.getDescription()) // 또는 OWNER
+        .status(Status.JOINED.getDisplayName())
+        .appliedAt(LocalDateTime.now())
+        .joinedAt(LocalDateTime.now())
+        .build();
+
+    groupParticipantsRepository.save(participants);
 
     return new GroupCreateResponse(savedGroup);
-  }
-
-  private void processTags(Group group, List<String> tagNames) {
-    for (String tagName : tagNames) {
-
-      Tag tag = tagRepository.findByName(tagName)
-          .orElseGet(() -> {
-            Tag newTag = new Tag(tagName);
-            return tagRepository.save(newTag);
-          });
-
-      GroupTag groupTag = GroupTag.builder()
-          .group(group)
-          .tag(tag)
-          .build();
-
-      group.getGroupTags().add(groupTag);
-
-      groupTagRepository.save(groupTag);
-    }
   }
 }

--- a/src/main/java/kr/ai/nemo/group/service/GroupCommandService.java
+++ b/src/main/java/kr/ai/nemo/group/service/GroupCommandService.java
@@ -9,7 +9,7 @@ import kr.ai.nemo.group.dto.GroupCreateResponse;
 import kr.ai.nemo.group.participants.domain.GroupParticipants;
 import kr.ai.nemo.group.participants.domain.enums.Role;
 import kr.ai.nemo.group.participants.domain.enums.Status;
-import kr.ai.nemo.group.participants.repository.GroupParticipantsRepository;
+import kr.ai.nemo.group.participants.service.GroupParticipantsService;
 import kr.ai.nemo.group.repository.GroupRepository;
 import kr.ai.nemo.user.domain.User;
 import kr.ai.nemo.user.service.UserQueryService;
@@ -22,13 +22,12 @@ import org.springframework.transaction.annotation.Transactional;
 public class GroupCommandService {
 
   private final GroupRepository groupRepository;
-  private final GroupTagService groupTagService;
   private final UserQueryService userQueryService;
-  private final GroupParticipantsRepository groupParticipantsRepository;
+  private final GroupTagService groupTagService;
+  private final GroupParticipantsService groupParticipantsService;
 
   @Transactional
   public GroupCreateResponse createGroup(@Valid GroupCreateRequest request, Long userId) {
-
     User user = userQueryService.findByIdOrThrow(userId);
 
     Group group = Group.builder()
@@ -46,23 +45,13 @@ public class GroupCommandService {
         .status(GroupStatus.ACTIVE)
         .build();
 
-
     Group savedGroup = groupRepository.save(group);
 
     if (request.getTags() != null && !request.getTags().isEmpty()) {
       groupTagService.assignTags(savedGroup, request.getTags());
     }
 
-    GroupParticipants participants = GroupParticipants.builder()
-        .user(user)
-        .group(group)
-        .role(Role.LEADER.getDescription()) // 또는 OWNER
-        .status(Status.JOINED.getDisplayName())
-        .appliedAt(LocalDateTime.now())
-        .joinedAt(LocalDateTime.now())
-        .build();
-
-    groupParticipantsRepository.save(participants);
+    groupParticipantsService.applyToGroup(savedGroup.getId(), user.getId(), Role.LEADER, Status.JOINED);
 
     return new GroupCreateResponse(savedGroup);
   }

--- a/src/main/java/kr/ai/nemo/group/service/GroupQueryService.java
+++ b/src/main/java/kr/ai/nemo/group/service/GroupQueryService.java
@@ -10,6 +10,7 @@ import kr.ai.nemo.group.dto.GroupDto;
 import kr.ai.nemo.group.dto.GroupListResponse;
 import kr.ai.nemo.group.dto.GroupSearchRequest;
 import kr.ai.nemo.group.repository.GroupRepository;
+import kr.ai.nemo.user.domain.User;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.Page;
@@ -62,9 +63,7 @@ public class GroupQueryService {
   }
 
   public GroupDetailResponse detailGroup(Long groupId) {
-    Group group = groupRepository.findById(groupId)
-        .orElseThrow(() -> new CustomException(ResponseCode.GROUP_NOT_FOUND));
-
+    Group group = findByIdOrThrow(groupId);
     return convertToDetailResponse(group);
   }
 
@@ -73,4 +72,8 @@ public class GroupQueryService {
     return PageRequest.of(request.getPage(), request.getSize(), sort);
   }
 
+  public Group findByIdOrThrow(Long groupId) {
+    return groupRepository.findById(groupId)
+        .orElseThrow(() -> new CustomException(ResponseCode.GROUP_NOT_FOUND));
+  }
 }

--- a/src/main/java/kr/ai/nemo/group/service/GroupQueryService.java
+++ b/src/main/java/kr/ai/nemo/group/service/GroupQueryService.java
@@ -10,7 +10,6 @@ import kr.ai.nemo.group.dto.GroupDto;
 import kr.ai.nemo.group.dto.GroupListResponse;
 import kr.ai.nemo.group.dto.GroupSearchRequest;
 import kr.ai.nemo.group.repository.GroupRepository;
-import kr.ai.nemo.user.domain.User;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.Page;
@@ -42,9 +41,6 @@ public class GroupQueryService {
     } else {
       groups = groupRepository.findAll(pageable);
     }
-
-
-
 
     List<GroupDto> groupDto = groups.getContent().stream()
         .map(GroupDto::from)

--- a/src/main/java/kr/ai/nemo/group/service/GroupTagService.java
+++ b/src/main/java/kr/ai/nemo/group/service/GroupTagService.java
@@ -1,0 +1,36 @@
+package kr.ai.nemo.group.service;
+
+import java.util.List;
+
+import kr.ai.nemo.group.domain.Group;
+import kr.ai.nemo.group.domain.GroupTag;
+import kr.ai.nemo.group.domain.Tag;
+import kr.ai.nemo.group.repository.GroupTagRepository;
+import kr.ai.nemo.group.repository.TagRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class GroupTagService {
+
+  private final TagRepository tagRepository;
+  private final GroupTagRepository groupTagRepository;
+
+  @Transactional
+  public void assignTags(Group group, List<String> tagNames) {
+    for (String tagName : tagNames) {
+      Tag tag = tagRepository.findByName(tagName)
+          .orElseGet(() -> tagRepository.save(new Tag(tagName)));
+
+      GroupTag groupTag = GroupTag.builder()
+          .group(group)
+          .tag(tag)
+          .build();
+
+      group.getGroupTags().add(groupTag);
+      groupTagRepository.save(groupTag);
+    }
+  }
+}

--- a/src/main/java/kr/ai/nemo/user/domain/User.java
+++ b/src/main/java/kr/ai/nemo/user/domain/User.java
@@ -4,6 +4,7 @@ import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.EnumType;
 import jakarta.persistence.Enumerated;
+import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
@@ -13,6 +14,7 @@ import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
 import kr.ai.nemo.group.domain.Group;
+import kr.ai.nemo.group.participants.domain.GroupParticipants;
 import kr.ai.nemo.user.domain.enums.UserStatus;
 import lombok.*;
 
@@ -58,4 +60,7 @@ public class User {
 
   @OneToMany(mappedBy = "owner")
   private List<Group> ownedGroups = new ArrayList<>();
+
+  @OneToMany(mappedBy = "user", fetch = FetchType.LAZY)
+  private List<GroupParticipants> groupParticipants = new ArrayList<>();
 }

--- a/src/main/java/kr/ai/nemo/user/repository/UserRepository.java
+++ b/src/main/java/kr/ai/nemo/user/repository/UserRepository.java
@@ -7,4 +7,6 @@ import org.springframework.data.jpa.repository.JpaRepository;
 public interface UserRepository extends JpaRepository<User, Long> {
 
   Optional<User> findByProviderAndProviderId(String provider, String providerId);
+
+  User getUserById(Long id);
 }


### PR DESCRIPTION
## What
→ 모임원(GroupParticipants) 도메인 및 관련 API를 구현했습니다.

## Why
→ 모임에 대한 참여, 조회 기능을 제공하기 위해 모임원 도메인 설계가 필요했습니다.

## Changes
→ GroupParticipants 엔티티 및 Enum(Status, Role) 정의
→ 모임 참여 신청 API (POST /api/v1/groups/{groupId}/applications) 구현
→ 모임원 list 조회 API (GET /api/v1/groups/{groupId}/participants) 구현
→ 나의 모임 list 조회 API (GET /api/v1/groups/me) 구현
→ GroupParticipantsService 및 Repository 로직 추가
→ 참여자 수 증가 시 group.currentUserCount 변경 반영
→ 이미 참여 중인 사용자의 중복 신청 방지 로직 추가

## Related Issue
#29 #30 #31 
