### PR TITLE
feat: 일정 삭제(취소) API 개발

### DIFF
--- a/src/main/java/kr/ai/nemo/common/exception/ResponseCode.java
+++ b/src/main/java/kr/ai/nemo/common/exception/ResponseCode.java
@@ -16,6 +16,8 @@ public enum ResponseCode {
   INVALID_REQUEST("INVALID_REQUEST", "입력값이 유효하지 않습니다.", HttpStatus.BAD_REQUEST),
   INVALID_ENUM("INVALID_ENUM", "올바르지 않은 타입입니다.", HttpStatus.BAD_REQUEST),
   MISSING_REQUIRED_PARAMETER("MISSING_REQUIRED_PARAMETER", "필수 요청 파라미터가 누락되었습니다.", HttpStatus.BAD_REQUEST),
+  SCHEDULE_ALREADY_ENDED("SCHEDULE_ALREADY_ENDED", "이미 종료된 일정은 취소할 수 없습니다.", HttpStatus.BAD_REQUEST),
+
 
   // 401 UNAUTHORIZED
   UNAUTHORIZED("UNAUTHORIZED", "인증이 필요합니다.", HttpStatus.UNAUTHORIZED),
@@ -24,11 +26,14 @@ public enum ResponseCode {
 
   // 403 FORBIDDEN
   ACCESS_DENIED("NO_PERMISSION", "접근 권한이 없습니다.", HttpStatus.FORBIDDEN),
+  SCHEDULE_DELETE_FORBIDDEN("SCHEDULE_DELETE_FORBIDDEN", "일정 생성자만 취소할 수 있습니다.", HttpStatus.FORBIDDEN),
+
 
   // 404 NOT FOUND
   USER_NOT_FOUND("USER_NOT_FOUND", "사용자를 찾을 수 없습니다.", HttpStatus.NOT_FOUND),
   GROUP_NOT_FOUND("GROUP_NOT_FOUND", "모임을 찾을 수 없습니다.", HttpStatus.NOT_FOUND),
   NOT_GROUP_MEMBER("PARTICIPANT+NOT_FOUND", "모임원이 아닙니다.", HttpStatus.NOT_FOUND),
+  SCHEDULE_NOT_FOUND("SCHEDULE_NOT_FOUND", "일정이 존재하지 않습니다.", HttpStatus.NOT_FOUND),
 
   // 409 Conflict
   ALREADY_APPLIED_OR_JOINED("ALREADY_APPLIED_OR_JOINED", "이미 신청했거나 참여 중인 사용자입니다.", HttpStatus.CONFLICT),

--- a/src/main/java/kr/ai/nemo/schedule/controller/ScheduleController.java
+++ b/src/main/java/kr/ai/nemo/schedule/controller/ScheduleController.java
@@ -9,6 +9,8 @@ import kr.ai.nemo.schedule.service.ScheduleCommandService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -26,5 +28,12 @@ public class ScheduleController {
     ScheduleCreateResponse response = scheduleCommandService.createSchedule(userId, request);
     URI location = UriGenerator.scheduleDetail(response.group().groupId());
     return ResponseEntity.created(location).body(ApiResponse.created(response));
+  }
+
+  @DeleteMapping("/{scheduleId}")
+  public ResponseEntity<ApiResponse<Void>> deleteSchedule(@PathVariable Long scheduleId) {
+    Long userId = Long.parseLong(SecurityContextHolder.getContext().getAuthentication().getName());
+    scheduleCommandService.deleteSchedule(userId, scheduleId);
+    return ResponseEntity.noContent().build();
   }
 }

--- a/src/main/java/kr/ai/nemo/schedule/service/ScheduleCommandService.java
+++ b/src/main/java/kr/ai/nemo/schedule/service/ScheduleCommandService.java
@@ -1,5 +1,8 @@
 package kr.ai.nemo.schedule.service;
 
+import java.time.LocalDateTime;
+import kr.ai.nemo.common.exception.CustomException;
+import kr.ai.nemo.common.exception.ResponseCode;
 import kr.ai.nemo.group.participants.service.GroupParticipantsService;
 import kr.ai.nemo.group.service.GroupQueryService;
 import kr.ai.nemo.schedule.domain.Schedule;
@@ -10,6 +13,7 @@ import kr.ai.nemo.schedule.repository.ScheduleRepository;
 import kr.ai.nemo.user.service.UserQueryService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @RequiredArgsConstructor
@@ -35,5 +39,21 @@ public class ScheduleCommandService {
     scheduleRepository.save(schedule);
 
     return ScheduleCreateResponse.from(schedule);
+  }
+
+  @Transactional
+  public void deleteSchedule(Long userId, Long scheduleId) {
+    Schedule schedule = scheduleRepository.findById(scheduleId)
+        .orElseThrow(() -> new CustomException(ResponseCode.SCHEDULE_NOT_FOUND));
+
+    if (schedule.getStartAt().isBefore(LocalDateTime.now())) {
+      throw new CustomException(ResponseCode.SCHEDULE_ALREADY_ENDED);
+    }
+
+    if (!schedule.getOwner().getId().equals(userId)) {
+      throw new CustomException(ResponseCode.SCHEDULE_DELETE_FORBIDDEN);
+    }
+
+    schedule.cancel();
   }
 }


### PR DESCRIPTION
## What
→ 일정을 취소하는 API 개발 완료하였습니다.

## Why
→ 일정 생성자는 일정을 자유롭게 취소할 수 있습니다.

## Changes
→ DELETE /api/v1/schedules/{scheduleId}
→ 일정 생성자만 삭제할 수 있으므로 error 메세지 추가하였습니다.
→ delete_at 이 추가되며, 상태값이 CANCELED로 변경되도록 합니다.