### PR TITLE
feat: 일정 상세 조회 API 개발 (#38)

### DIFF
--- a/src/main/java/kr/ai/nemo/schedule/controller/ScheduleController.java
+++ b/src/main/java/kr/ai/nemo/schedule/controller/ScheduleController.java
@@ -7,6 +7,7 @@ import kr.ai.nemo.schedule.dto.ScheduleCreateRequest;
 import kr.ai.nemo.schedule.dto.ScheduleCreateResponse;
 import kr.ai.nemo.schedule.dto.ScheduleDetailResponse;
 import kr.ai.nemo.schedule.service.ScheduleCommandService;
+import kr.ai.nemo.schedule.service.ScheduleQueryService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.context.SecurityContextHolder;
@@ -23,6 +24,7 @@ import org.springframework.web.bind.annotation.RestController;
 @RequiredArgsConstructor
 public class ScheduleController {
   private final ScheduleCommandService scheduleCommandService;
+  private final ScheduleQueryService scheduleQueryService;
 
   @PostMapping
   public ResponseEntity<ApiResponse<ScheduleCreateResponse>> schedule(@RequestBody ScheduleCreateRequest request) {

--- a/src/main/java/kr/ai/nemo/schedule/controller/ScheduleController.java
+++ b/src/main/java/kr/ai/nemo/schedule/controller/ScheduleController.java
@@ -5,11 +5,13 @@ import kr.ai.nemo.common.UriGenerator;
 import kr.ai.nemo.common.exception.ApiResponse;
 import kr.ai.nemo.schedule.dto.ScheduleCreateRequest;
 import kr.ai.nemo.schedule.dto.ScheduleCreateResponse;
+import kr.ai.nemo.schedule.dto.ScheduleDetailResponse;
 import kr.ai.nemo.schedule.service.ScheduleCommandService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -35,5 +37,11 @@ public class ScheduleController {
     Long userId = Long.parseLong(SecurityContextHolder.getContext().getAuthentication().getName());
     scheduleCommandService.deleteSchedule(userId, scheduleId);
     return ResponseEntity.noContent().build();
+  }
+
+  @GetMapping("/{scheduleId}")
+  public ResponseEntity<ApiResponse<ScheduleDetailResponse>> getScheduleDetail(@PathVariable Long scheduleId) {
+    ScheduleDetailResponse response = scheduleQueryService.getScheduleDetail(scheduleId);
+    return ResponseEntity.ok(ApiResponse.success(response));
   }
 }

--- a/src/main/java/kr/ai/nemo/schedule/dto/ScheduleDetailResponse.java
+++ b/src/main/java/kr/ai/nemo/schedule/dto/ScheduleDetailResponse.java
@@ -1,0 +1,52 @@
+package kr.ai.nemo.schedule.dto;
+
+import java.time.format.DateTimeFormatter;
+import java.util.List;
+import kr.ai.nemo.schedule.domain.Schedule;
+import kr.ai.nemo.schedule.participants.domain.ScheduleParticipant;
+
+public record ScheduleDetailResponse(
+    Long id,
+    String title,
+    String startAt,
+    String address,
+    Long ownerId,
+    String createdAt,
+    String description,
+    GroupInfo group,
+    List<ParticipantInfo> participants
+) {
+  public record GroupInfo(Long groupId, String name, int currentUser) {}
+
+  public record ParticipantInfo(Long id, UserInfo user, String status) {}
+
+  public record UserInfo(Long userId, String nickname, String profileImage) {}
+
+  public static ScheduleDetailResponse from(Schedule schedule, List<ScheduleParticipant> participants) {
+    return new ScheduleDetailResponse(
+        schedule.getId(),
+        schedule.getTitle(),
+        schedule.getStartAt().format(DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm")),
+        schedule.getAddress(),
+        schedule.getOwner().getId(),
+        schedule.getCreatedAt().format(DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm")),
+        schedule.getDescription(),
+        new GroupInfo(
+            schedule.getGroup().getId(),
+            schedule.getGroup().getName(),
+            schedule.getGroup().getCurrentUserCount()
+        ),
+        participants.stream()
+            .map(p -> new ParticipantInfo(
+                p.getId(),
+                new UserInfo(
+                    p.getUser().getId(),
+                    p.getUser().getNickname(),
+                    p.getUser().getProfileImageUrl()
+                ),
+                p.getStatus().name()
+            ))
+            .toList()
+    );
+  }
+}

--- a/src/main/java/kr/ai/nemo/schedule/participants/domain/ScheduleParticipant.java
+++ b/src/main/java/kr/ai/nemo/schedule/participants/domain/ScheduleParticipant.java
@@ -1,0 +1,73 @@
+package kr.ai.nemo.schedule.participants.domain;
+
+import jakarta.persistence.*;
+import java.time.LocalDateTime;
+
+import kr.ai.nemo.schedule.domain.Schedule;
+import kr.ai.nemo.user.domain.User;
+import kr.ai.nemo.schedule.participants.domain.enums.ScheduleParticipantStatus;
+import lombok.*;
+
+@Entity
+@Table(name = "schedule_participants",
+    indexes = {
+        @Index(name = "idx_user_id_status_joined_at", columnList = "user_id, status, joined_at")
+    }
+)
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Builder
+public class ScheduleParticipant {
+
+  @Id
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
+  private Long id;
+
+  @ManyToOne(fetch = FetchType.LAZY)
+  @JoinColumn(name = "schedule_id", nullable = false)
+  private Schedule schedule;
+
+  @ManyToOne(fetch = FetchType.LAZY)
+  @JoinColumn(name = "user_id", nullable = false)
+  private User user;
+
+  @Enumerated(EnumType.STRING)
+  @Column(nullable = false)
+  private ScheduleParticipantStatus status;
+
+  @Column(name = "joined_at")
+  private LocalDateTime joinedAt;
+
+  @Column(name = "created_at", updatable = false)
+  private LocalDateTime createdAt;
+
+  @Column(name = "updated_at")
+  private LocalDateTime updatedAt;
+
+  @PrePersist
+  protected void onCreate() {
+    this.createdAt = LocalDateTime.now();
+    this.updatedAt = LocalDateTime.now();
+  }
+
+  @PreUpdate
+  protected void onUpdate() {
+    this.updatedAt = LocalDateTime.now();
+  }
+
+  public void accept() {
+    this.status = ScheduleParticipantStatus.ACCEPTED;
+    this.joinedAt = LocalDateTime.now();
+  }
+
+  public void reject() {
+    this.status = ScheduleParticipantStatus.REJECTED;
+    this.joinedAt = null;
+  }
+
+  public void cancel() {
+    this.status = ScheduleParticipantStatus.CANCELED;
+    this.joinedAt = null;
+  }
+}

--- a/src/main/java/kr/ai/nemo/schedule/participants/domain/enums/ScheduleParticipantStatus.java
+++ b/src/main/java/kr/ai/nemo/schedule/participants/domain/enums/ScheduleParticipantStatus.java
@@ -1,0 +1,8 @@
+package kr.ai.nemo.schedule.participants.domain.enums;
+
+public enum ScheduleParticipantStatus {
+  PENDING,
+  ACCEPTED,
+  REJECTED,
+  CANCELED
+}

--- a/src/main/java/kr/ai/nemo/schedule/participants/repository/ScheduleParticipantRepository.java
+++ b/src/main/java/kr/ai/nemo/schedule/participants/repository/ScheduleParticipantRepository.java
@@ -1,0 +1,10 @@
+package kr.ai.nemo.schedule.participants.repository;
+
+import java.util.List;
+import kr.ai.nemo.schedule.participants.domain.ScheduleParticipant;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface ScheduleParticipantRepository extends JpaRepository<ScheduleParticipant, Long> {
+
+  List<ScheduleParticipant> findByScheduleId(Long scheduleId);
+}

--- a/src/main/java/kr/ai/nemo/schedule/service/ScheduleCommandService.java
+++ b/src/main/java/kr/ai/nemo/schedule/service/ScheduleCommandService.java
@@ -43,8 +43,7 @@ public class ScheduleCommandService {
 
   @Transactional
   public void deleteSchedule(Long userId, Long scheduleId) {
-    Schedule schedule = scheduleRepository.findById(scheduleId)
-        .orElseThrow(() -> new CustomException(ResponseCode.SCHEDULE_NOT_FOUND));
+    Schedule schedule = findByIdOrThrow(scheduleId);
 
     if (schedule.getStartAt().isBefore(LocalDateTime.now())) {
       throw new CustomException(ResponseCode.SCHEDULE_ALREADY_ENDED);
@@ -55,5 +54,10 @@ public class ScheduleCommandService {
     }
 
     schedule.cancel();
+  }
+
+  public Schedule findByIdOrThrow(Long scheduleId) {
+    return scheduleRepository.findById(scheduleId)
+        .orElseThrow(() -> new CustomException(ResponseCode.SCHEDULE_NOT_FOUND));
   }
 }

--- a/src/main/java/kr/ai/nemo/schedule/service/ScheduleQueryService.java
+++ b/src/main/java/kr/ai/nemo/schedule/service/ScheduleQueryService.java
@@ -1,5 +1,22 @@
 package kr.ai.nemo.schedule.service;
 
-public class ScheduleQueryService {
+import java.util.List;
+import kr.ai.nemo.schedule.domain.Schedule;
+import kr.ai.nemo.schedule.dto.ScheduleDetailResponse;
+import kr.ai.nemo.schedule.participants.domain.ScheduleParticipant;
+import kr.ai.nemo.schedule.participants.repository.ScheduleParticipantRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
 
+@Service
+@RequiredArgsConstructor
+public class ScheduleQueryService {
+  private final ScheduleCommandService scheduleCommandService;
+  private final ScheduleParticipantRepository scheduleParticipantRepository;
+
+  public ScheduleDetailResponse getScheduleDetail(Long scheduleId) {
+    Schedule schedule = scheduleCommandService.findByIdOrThrow(scheduleId);
+    List<ScheduleParticipant> participants = scheduleParticipantRepository.findByScheduleId(scheduleId);
+    return ScheduleDetailResponse.from(schedule, participants);
+  }
 }


### PR DESCRIPTION
## What
→ 일정 상세를 조회하는 API 개발 완료하였습니다.

## Why
→ 사용자는 일정의 상세 내용을 조회할 수 있습니다.

## Changes
→ 일정 상세 내용을 조회할 수 있도록 service, comtroller, repository를 추가하였습니다.
→ 누구나 조회할 수 있기 때문에 SecurityConfig 추가하였습니다.
→ 일정 참여자 조회를 위해 일정 참여자 domain을 추가하였습니다.


## Related Issue
> #36 #37 #39 