### PR TITLE
feat: 모임 일정 list 조회 API 개발

### DIFF
--- a/src/main/java/kr/ai/nemo/config/SecurityConfig.java
+++ b/src/main/java/kr/ai/nemo/config/SecurityConfig.java
@@ -30,6 +30,7 @@ public class SecurityConfig {
             .requestMatchers(HttpMethod.GET, "/api/v1/auth/*").permitAll()
             .requestMatchers(HttpMethod.GET, "/api/v1/groups/me").authenticated()
             .requestMatchers(HttpMethod.GET, "/api/v1/groups/**").permitAll()
+            .requestMatchers(HttpMethod.GET, "/api/v1/schedules/**").permitAll()
             .requestMatchers("/test/token/**").permitAll()
             .anyRequest().authenticated()
         )

--- a/src/main/java/kr/ai/nemo/group/controller/GroupController.java
+++ b/src/main/java/kr/ai/nemo/group/controller/GroupController.java
@@ -12,6 +12,9 @@ import kr.ai.nemo.group.dto.GroupSearchRequest;
 import kr.ai.nemo.group.service.AiGroupGenerateClient;
 import kr.ai.nemo.group.service.GroupCommandService;
 import kr.ai.nemo.group.service.GroupQueryService;
+import kr.ai.nemo.schedule.dto.PageRequestDto;
+import kr.ai.nemo.schedule.dto.ScheduleListResponse;
+import kr.ai.nemo.schedule.service.ScheduleQueryService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
@@ -36,6 +39,7 @@ public class GroupController {
   private final AiGroupGenerateClient aiGroupGenerateClient;
   private final GroupCommandService groupCommandService;
   private final GroupQueryService groupQueryService;
+  private final ScheduleQueryService scheduleQueryService;
 
   @PostMapping("/ai-generate")
   public ResponseEntity<ApiResponse<GroupAiGenerateResponse>> generateGroupInfo(@Valid @RequestBody GroupAiGenerateRequest request) {
@@ -73,5 +77,15 @@ public class GroupController {
   @GetMapping("/search")
   public ResponseEntity<ApiResponse<GroupListResponse>> searchGroups(@ModelAttribute GroupSearchRequest request) {
     return ResponseEntity.ok(ApiResponse.success(groupQueryService.getGroups(request)));
+  }
+
+  @GetMapping("/{groupId}/schedules")
+  public ResponseEntity<ApiResponse<ScheduleListResponse>> getGroupSchedules(
+      @PathVariable Long groupId,
+      @Valid PageRequestDto pageRequestDto
+  ) {
+    return ResponseEntity.ok(ApiResponse.success(
+        scheduleQueryService.getGroupSchedules(groupId, pageRequestDto.toPageRequest())
+    ));
   }
 }

--- a/src/main/java/kr/ai/nemo/group/dto/GroupListResponse.java
+++ b/src/main/java/kr/ai/nemo/group/dto/GroupListResponse.java
@@ -1,27 +1,22 @@
 package kr.ai.nemo.group.dto;
 
 import java.util.List;
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
+import org.springframework.data.domain.Page;
 
-@Getter
-@NoArgsConstructor
-@AllArgsConstructor
-@Builder
-public class GroupListResponse {
-  private List<GroupDto> groups;
-  private int totalCount;
-  private int page;
-  private int size;
-
-  public static GroupListResponse from(List<GroupDto> groups, int totalCount, int page, int size) {
-    return GroupListResponse.builder()
-        .groups(groups)
-        .totalCount(totalCount)
-        .page(page)
-        .size(size)
-        .build();
+public record GroupListResponse(
+    List<GroupDto> groups,
+    int totalPages,
+    long totalElements,
+    int pageNumber,
+    boolean isLast
+) {
+  public static GroupListResponse from(Page<GroupDto> page) {
+    return new GroupListResponse(
+        page.getContent(),
+        page.getTotalPages(),
+        page.getTotalElements(),
+        page.getNumber(),
+        page.isLast()
+    );
   }
 }

--- a/src/main/java/kr/ai/nemo/group/service/GroupQueryService.java
+++ b/src/main/java/kr/ai/nemo/group/service/GroupQueryService.java
@@ -1,7 +1,5 @@
 package kr.ai.nemo.group.service;
 
-import java.util.List;
-import java.util.stream.Collectors;
 import kr.ai.nemo.common.exception.CustomException;
 import kr.ai.nemo.common.exception.ResponseCode;
 import kr.ai.nemo.group.domain.Group;

--- a/src/main/java/kr/ai/nemo/group/service/GroupQueryService.java
+++ b/src/main/java/kr/ai/nemo/group/service/GroupQueryService.java
@@ -34,24 +34,15 @@ public class GroupQueryService {
 
     if (request.getCategoryEnum() != null) {
       groups = groupRepository.findByCategory(request.getCategoryEnum(), pageable);
-
     } else if (request.getKeyword() != null && !request.getKeyword().isBlank()) {
       groups = groupRepository.searchWithKeywordOnly(request.getKeyword(), pageable);
-
     } else {
       groups = groupRepository.findAll(pageable);
     }
 
-    List<GroupDto> groupDto = groups.getContent().stream()
-        .map(GroupDto::from)
-        .collect(Collectors.toList());
+    Page<GroupDto> groupDtoPage = groups.map(GroupDto::from);
 
-    return GroupListResponse.from(
-        groupDto,
-        (int) groups.getTotalElements(),
-        groups.getNumber(),
-        groups.getSize()
-    );
+    return GroupListResponse.from(groupDtoPage);
   }
 
   private GroupDetailResponse convertToDetailResponse(Group group) {

--- a/src/main/java/kr/ai/nemo/schedule/controller/ScheduleController.java
+++ b/src/main/java/kr/ai/nemo/schedule/controller/ScheduleController.java
@@ -1,11 +1,14 @@
 package kr.ai.nemo.schedule.controller;
 
+import jakarta.validation.Valid;
 import java.net.URI;
 import kr.ai.nemo.common.UriGenerator;
 import kr.ai.nemo.common.exception.ApiResponse;
+import kr.ai.nemo.schedule.dto.PageRequestDto;
 import kr.ai.nemo.schedule.dto.ScheduleCreateRequest;
 import kr.ai.nemo.schedule.dto.ScheduleCreateResponse;
 import kr.ai.nemo.schedule.dto.ScheduleDetailResponse;
+import kr.ai.nemo.schedule.dto.ScheduleListResponse;
 import kr.ai.nemo.schedule.service.ScheduleCommandService;
 import kr.ai.nemo.schedule.service.ScheduleQueryService;
 import lombok.RequiredArgsConstructor;

--- a/src/main/java/kr/ai/nemo/schedule/controller/ScheduleController.java
+++ b/src/main/java/kr/ai/nemo/schedule/controller/ScheduleController.java
@@ -1,14 +1,11 @@
 package kr.ai.nemo.schedule.controller;
 
-import jakarta.validation.Valid;
 import java.net.URI;
 import kr.ai.nemo.common.UriGenerator;
 import kr.ai.nemo.common.exception.ApiResponse;
-import kr.ai.nemo.schedule.dto.PageRequestDto;
 import kr.ai.nemo.schedule.dto.ScheduleCreateRequest;
 import kr.ai.nemo.schedule.dto.ScheduleCreateResponse;
 import kr.ai.nemo.schedule.dto.ScheduleDetailResponse;
-import kr.ai.nemo.schedule.dto.ScheduleListResponse;
 import kr.ai.nemo.schedule.service.ScheduleCommandService;
 import kr.ai.nemo.schedule.service.ScheduleQueryService;
 import lombok.RequiredArgsConstructor;

--- a/src/main/java/kr/ai/nemo/schedule/dto/PageRequestDto.java
+++ b/src/main/java/kr/ai/nemo/schedule/dto/PageRequestDto.java
@@ -1,0 +1,25 @@
+package kr.ai.nemo.schedule.dto;
+
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Sort;
+import jakarta.validation.constraints.Min;
+
+public record PageRequestDto(
+    @Min(0) int page,
+    @Min(1) int size,
+    String sort,
+    String direction
+) {
+  public PageRequestDto {
+    if (sort == null || sort.isBlank()) sort = "createdAt";
+    if (direction == null || direction.isBlank()) direction = "desc";
+  }
+
+  public PageRequest toPageRequest() {
+    return PageRequest.of(
+        page,
+        size,
+        Sort.by(Sort.Direction.fromString(direction), sort)
+    );
+  }
+}

--- a/src/main/java/kr/ai/nemo/schedule/dto/ScheduleListResponse.java
+++ b/src/main/java/kr/ai/nemo/schedule/dto/ScheduleListResponse.java
@@ -1,0 +1,21 @@
+package kr.ai.nemo.schedule.dto;
+
+import java.util.List;
+
+public record ScheduleListResponse(
+    List<ScheduleSummary> schedules,
+    int totalPages,
+    long totalElements,
+    int pageNumber,
+    boolean isLast
+) {
+  public record ScheduleSummary(
+      Long id,
+      String title,
+      String startAt,
+      String address,
+      String description,
+      String ownerName,
+      int currentUser
+  ) {}
+}

--- a/src/main/java/kr/ai/nemo/schedule/repository/ScheduleRepository.java
+++ b/src/main/java/kr/ai/nemo/schedule/repository/ScheduleRepository.java
@@ -1,10 +1,13 @@
 package kr.ai.nemo.schedule.repository;
 
 import kr.ai.nemo.schedule.domain.Schedule;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
 @Repository
 public interface ScheduleRepository extends JpaRepository<Schedule, Long> {
 
+  Page<Schedule> findByGroupId(Long groupId, PageRequest pageRequest);
 }

--- a/src/main/java/kr/ai/nemo/schedule/service/ScheduleQueryService.java
+++ b/src/main/java/kr/ai/nemo/schedule/service/ScheduleQueryService.java
@@ -1,17 +1,23 @@
 package kr.ai.nemo.schedule.service;
 
+import java.time.format.DateTimeFormatter;
 import java.util.List;
 import kr.ai.nemo.schedule.domain.Schedule;
 import kr.ai.nemo.schedule.dto.ScheduleDetailResponse;
+import kr.ai.nemo.schedule.dto.ScheduleListResponse;
 import kr.ai.nemo.schedule.participants.domain.ScheduleParticipant;
 import kr.ai.nemo.schedule.participants.repository.ScheduleParticipantRepository;
+import kr.ai.nemo.schedule.repository.ScheduleRepository;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
 import org.springframework.stereotype.Service;
 
 @Service
 @RequiredArgsConstructor
 public class ScheduleQueryService {
   private final ScheduleCommandService scheduleCommandService;
+  private final ScheduleRepository scheduleRepository;
   private final ScheduleParticipantRepository scheduleParticipantRepository;
 
   public ScheduleDetailResponse getScheduleDetail(Long scheduleId) {
@@ -19,4 +25,29 @@ public class ScheduleQueryService {
     List<ScheduleParticipant> participants = scheduleParticipantRepository.findByScheduleId(scheduleId);
     return ScheduleDetailResponse.from(schedule, participants);
   }
+
+  public ScheduleListResponse getGroupSchedules(Long groupId, PageRequest pageRequest) {
+    Page<Schedule> page = scheduleRepository.findByGroupId(groupId, pageRequest);
+
+    List<ScheduleListResponse.ScheduleSummary> summaries = page.getContent().stream()
+        .map(schedule -> new ScheduleListResponse.ScheduleSummary(
+            schedule.getId(),
+            schedule.getTitle(),
+            schedule.getStartAt().format(DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm")),
+            schedule.getAddress(),
+            schedule.getDescription(),
+            schedule.getOwner().getNickname(),
+            schedule.getCurrentUserCount()
+        ))
+        .toList();
+
+    return new ScheduleListResponse(
+        summaries,
+        page.getTotalPages(),
+        page.getTotalElements(),
+        page.getNumber(),
+        page.isLast()
+    );
+  }
+
 }


### PR DESCRIPTION
## What
→ 모임의 일정 list를 조회하는 API 개발 완료하였습니다.

## Why
→ 모임별 어떤 일정이 있었는지, 어떤 일정들이 있는지 확인할 수 있습니다.

## Changes
→ Get /api/v1/group/{groupId}/schedules API 개발하였습니다.
→ 누구나 조회가 가능하므로 SecurityConfig 재확인 하였습니다.
→ Group 도메인 내 Controller 에 GetMapping 추가하였습니다.
