### PR TITLE
feat: 일정 참석/거절 API 개발 완료 (#48)

### DIFF
--- a/src/main/java/kr/ai/nemo/common/exception/ResponseCode.java
+++ b/src/main/java/kr/ai/nemo/common/exception/ResponseCode.java
@@ -37,6 +37,7 @@ public enum ResponseCode {
 
   // 409 Conflict
   ALREADY_APPLIED_OR_JOINED("ALREADY_APPLIED_OR_JOINED", "이미 신청했거나 참여 중인 사용자입니다.", HttpStatus.CONFLICT),
+  SCHEDULE_ALREADY_DECIDED("SCHEDULE_ALREADY_DECIDED", "이미 응답하셨습니다.", HttpStatus.CONFLICT),
 
   // 500 INTERNAL SERVER ERROR
   INTERNAL_SERVER_ERROR("INTERNAL_SERVER_ERROR", "서버 오류가 발생했습니다.", HttpStatus.INTERNAL_SERVER_ERROR),

--- a/src/main/java/kr/ai/nemo/group/domain/Group.java
+++ b/src/main/java/kr/ai/nemo/group/domain/Group.java
@@ -118,7 +118,11 @@ public class Group {
     return Category.toDisplayName(this.category);
   }
 
-  public void addCurrentCount() {
+  public void addCurrentUserCount() {
     this.currentUserCount++;
+  }
+
+  public void addCompleteSchedule() {
+    this.completedScheduleTotal++;
   }
 }

--- a/src/main/java/kr/ai/nemo/group/participants/domain/enums/Status.java
+++ b/src/main/java/kr/ai/nemo/group/participants/domain/enums/Status.java
@@ -13,4 +13,8 @@ public enum Status {
   REJECTED("거절됨");
 
   private final String displayName;
+
+  public boolean isJoined() {
+    return this == JOINED;
+  }
 }

--- a/src/main/java/kr/ai/nemo/schedule/controller/ScheduleController.java
+++ b/src/main/java/kr/ai/nemo/schedule/controller/ScheduleController.java
@@ -27,7 +27,7 @@ public class ScheduleController {
   private final ScheduleQueryService scheduleQueryService;
 
   @PostMapping
-  public ResponseEntity<ApiResponse<ScheduleCreateResponse>> schedule(@RequestBody ScheduleCreateRequest request) {
+  public ResponseEntity<ApiResponse<ScheduleCreateResponse>> createSchedule(@RequestBody ScheduleCreateRequest request) {
     Long userId = Long.parseLong(SecurityContextHolder.getContext().getAuthentication().getName());
     ScheduleCreateResponse response = scheduleCommandService.createSchedule(userId, request);
     URI location = UriGenerator.scheduleDetail(response.group().groupId());

--- a/src/main/java/kr/ai/nemo/schedule/participants/controller/ScheduleParticipantsController.java
+++ b/src/main/java/kr/ai/nemo/schedule/participants/controller/ScheduleParticipantsController.java
@@ -1,0 +1,26 @@
+package kr.ai.nemo.schedule.participants.controller;
+
+import jakarta.validation.Valid;
+import kr.ai.nemo.schedule.participants.dto.ScheduleParticipantDecisionRequest;
+import kr.ai.nemo.schedule.participants.service.ScheduleParticipantsService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/schedules")
+public class ScheduleParticipantsController {
+  private final ScheduleParticipantsService scheduleParticipantsService;
+
+  @PatchMapping("/{scheduleId}/participants")
+  public ResponseEntity<Object> updateParticipants(@PathVariable Long scheduleId, @Valid @RequestBody ScheduleParticipantDecisionRequest request, @AuthenticationPrincipal Long userId) {
+    scheduleParticipantsService.decideParticipation(scheduleId, userId, request.status());
+    return ResponseEntity.noContent().build();
+  }
+}

--- a/src/main/java/kr/ai/nemo/schedule/participants/domain/ScheduleParticipant.java
+++ b/src/main/java/kr/ai/nemo/schedule/participants/domain/ScheduleParticipant.java
@@ -32,10 +32,12 @@ public class ScheduleParticipant {
   @JoinColumn(name = "user_id", nullable = false)
   private User user;
 
+  @Setter
   @Enumerated(EnumType.STRING)
   @Column(nullable = false)
   private ScheduleParticipantStatus status;
 
+  @Setter
   @Column(name = "joined_at")
   private LocalDateTime joinedAt;
 
@@ -63,11 +65,6 @@ public class ScheduleParticipant {
 
   public void reject() {
     this.status = ScheduleParticipantStatus.REJECTED;
-    this.joinedAt = null;
-  }
-
-  public void cancel() {
-    this.status = ScheduleParticipantStatus.CANCELED;
     this.joinedAt = null;
   }
 }

--- a/src/main/java/kr/ai/nemo/schedule/participants/domain/enums/ScheduleParticipantStatus.java
+++ b/src/main/java/kr/ai/nemo/schedule/participants/domain/enums/ScheduleParticipantStatus.java
@@ -3,6 +3,5 @@ package kr.ai.nemo.schedule.participants.domain.enums;
 public enum ScheduleParticipantStatus {
   PENDING,
   ACCEPTED,
-  REJECTED,
-  CANCELED
+  REJECTED
 }

--- a/src/main/java/kr/ai/nemo/schedule/participants/dto/ScheduleParticipantDecisionRequest.java
+++ b/src/main/java/kr/ai/nemo/schedule/participants/dto/ScheduleParticipantDecisionRequest.java
@@ -1,0 +1,8 @@
+package kr.ai.nemo.schedule.participants.dto;
+
+import jakarta.validation.constraints.NotNull;
+import kr.ai.nemo.schedule.participants.domain.enums.ScheduleParticipantStatus;
+
+public record ScheduleParticipantDecisionRequest(
+    @NotNull ScheduleParticipantStatus status
+) {}

--- a/src/main/java/kr/ai/nemo/schedule/participants/repository/ScheduleParticipantRepository.java
+++ b/src/main/java/kr/ai/nemo/schedule/participants/repository/ScheduleParticipantRepository.java
@@ -1,10 +1,14 @@
 package kr.ai.nemo.schedule.participants.repository;
 
 import java.util.List;
+import kr.ai.nemo.schedule.domain.Schedule;
 import kr.ai.nemo.schedule.participants.domain.ScheduleParticipant;
+import kr.ai.nemo.user.domain.User;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface ScheduleParticipantRepository extends JpaRepository<ScheduleParticipant, Long> {
 
   List<ScheduleParticipant> findByScheduleId(Long scheduleId);
+
+  boolean existsByScheduleAndUser(Schedule schedule, User user);
 }

--- a/src/main/java/kr/ai/nemo/schedule/participants/repository/ScheduleParticipantRepository.java
+++ b/src/main/java/kr/ai/nemo/schedule/participants/repository/ScheduleParticipantRepository.java
@@ -1,6 +1,7 @@
 package kr.ai.nemo.schedule.participants.repository;
 
 import java.util.List;
+import java.util.Optional;
 import kr.ai.nemo.schedule.domain.Schedule;
 import kr.ai.nemo.schedule.participants.domain.ScheduleParticipant;
 import kr.ai.nemo.user.domain.User;
@@ -11,4 +12,6 @@ public interface ScheduleParticipantRepository extends JpaRepository<SchedulePar
   List<ScheduleParticipant> findByScheduleId(Long scheduleId);
 
   boolean existsByScheduleAndUser(Schedule schedule, User user);
+
+  Optional<ScheduleParticipant> findByScheduleIdAndUserId(Long scheduleId, Long userId);
 }

--- a/src/main/java/kr/ai/nemo/schedule/participants/service/ScheduleParticipantsService.java
+++ b/src/main/java/kr/ai/nemo/schedule/participants/service/ScheduleParticipantsService.java
@@ -1,0 +1,64 @@
+package kr.ai.nemo.schedule.participants.service;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import kr.ai.nemo.group.domain.Group;
+import kr.ai.nemo.group.participants.domain.GroupParticipants;
+import kr.ai.nemo.schedule.domain.Schedule;
+import kr.ai.nemo.schedule.domain.enums.ScheduleStatus;
+import kr.ai.nemo.schedule.participants.domain.ScheduleParticipant;
+import kr.ai.nemo.schedule.participants.domain.enums.ScheduleParticipantStatus;
+import kr.ai.nemo.schedule.participants.repository.ScheduleParticipantRepository;
+import kr.ai.nemo.schedule.repository.ScheduleRepository;
+import kr.ai.nemo.user.domain.User;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class ScheduleParticipantsService {
+  private final ScheduleParticipantRepository scheduleParticipantRepository;
+  private final ScheduleRepository scheduleRepository;
+
+  @Transactional
+  public void addAllParticipantsForNewSchedule(Schedule schedule) {
+    Group group = schedule.getGroup();
+
+    List<User> users = group.getGroupParticipants().stream()
+        .filter(p -> p.getStatus().isJoined())
+        .map(GroupParticipants::getUser)
+        .toList();
+
+    for (User user : users) {
+      ScheduleParticipantStatus status = user.getId().equals(schedule.getOwner().getId())
+          ? ScheduleParticipantStatus.ACCEPTED
+          : ScheduleParticipantStatus.PENDING;
+
+      scheduleParticipantRepository.save(ScheduleParticipant.builder()
+          .schedule(schedule)
+          .user(user)
+          .status(status)
+          .build());
+    }
+  }
+
+  @Transactional
+  public void addParticipantToUpcomingSchedules(Group group, User user) {
+    List<Schedule> schedules = scheduleRepository.findByGroupAndStatus(group, ScheduleStatus.RECRUITING);
+
+    for (Schedule schedule : schedules) {
+      boolean exists = scheduleParticipantRepository.existsByScheduleAndUser(schedule, user);
+      if (!exists) {
+        ScheduleParticipant participant = ScheduleParticipant.builder()
+            .schedule(schedule)
+            .user(user)
+            .status(ScheduleParticipantStatus.PENDING)
+            .createdAt(LocalDateTime.now())
+            .build();
+
+        scheduleParticipantRepository.save(participant);
+      }
+    }
+  }
+}

--- a/src/main/java/kr/ai/nemo/schedule/participants/service/ScheduleParticipantsService.java
+++ b/src/main/java/kr/ai/nemo/schedule/participants/service/ScheduleParticipantsService.java
@@ -2,6 +2,8 @@ package kr.ai.nemo.schedule.participants.service;
 
 import java.time.LocalDateTime;
 import java.util.List;
+import kr.ai.nemo.common.exception.CustomException;
+import kr.ai.nemo.common.exception.ResponseCode;
 import kr.ai.nemo.group.domain.Group;
 import kr.ai.nemo.group.participants.domain.GroupParticipants;
 import kr.ai.nemo.schedule.domain.Schedule;
@@ -60,5 +62,19 @@ public class ScheduleParticipantsService {
         scheduleParticipantRepository.save(participant);
       }
     }
+  }
+
+  @Transactional
+  public void decideParticipation(Long scheduleId, Long userId, ScheduleParticipantStatus status) {
+    ScheduleParticipant participant = scheduleParticipantRepository
+        .findByScheduleIdAndUserId(scheduleId, userId)
+        .orElseThrow(() -> new CustomException(ResponseCode.SCHEDULE_ALREADY_DECIDED));
+
+    if (participant.getStatus() != ScheduleParticipantStatus.PENDING) {
+      throw new CustomException(ResponseCode.SCHEDULE_ALREADY_DECIDED);
+    }
+
+    participant.setStatus(status);
+    participant.setJoinedAt(LocalDateTime.now());
   }
 }

--- a/src/main/java/kr/ai/nemo/schedule/repository/ScheduleRepository.java
+++ b/src/main/java/kr/ai/nemo/schedule/repository/ScheduleRepository.java
@@ -1,6 +1,9 @@
 package kr.ai.nemo.schedule.repository;
 
+import java.util.List;
+import kr.ai.nemo.group.domain.Group;
 import kr.ai.nemo.schedule.domain.Schedule;
+import kr.ai.nemo.schedule.domain.enums.ScheduleStatus;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -10,4 +13,6 @@ import org.springframework.stereotype.Repository;
 public interface ScheduleRepository extends JpaRepository<Schedule, Long> {
 
   Page<Schedule> findByGroupId(Long groupId, PageRequest pageRequest);
+
+  List<Schedule> findByGroupAndStatus(Group group, ScheduleStatus scheduleStatus);
 }


### PR DESCRIPTION
## What
→ 사용자가 일정 참석/거절을 응답하는 API 개발 완료하였습니다.

## Why
→ 사용자가 일정을 참석할지 거절할지 결정할 수 있습니다,
→ 다른 사람들은 일정에 누가 참여하는지 알 수 있습니다.

## Changes
→ Controller 내 API 로직 추가하였습니다.
→ Service 내 일정 참여자의 상태값을 바꾸는 setter를 추가하였습니다.
→ Repository에서 이미 응답한 경우에는 다시 선택할 수 없도록 하였습니다.