### PR TITLE
feat: 나의 일정 목록 조회 API 구현 (#49)

### DIFF
--- a/src/main/java/kr/ai/nemo/schedule/controller/ScheduleController.java
+++ b/src/main/java/kr/ai/nemo/schedule/controller/ScheduleController.java
@@ -3,6 +3,7 @@ package kr.ai.nemo.schedule.controller;
 import java.net.URI;
 import kr.ai.nemo.common.UriGenerator;
 import kr.ai.nemo.common.exception.ApiResponse;
+import kr.ai.nemo.schedule.dto.MySchedulesResponse;
 import kr.ai.nemo.schedule.dto.ScheduleCreateRequest;
 import kr.ai.nemo.schedule.dto.ScheduleCreateResponse;
 import kr.ai.nemo.schedule.dto.ScheduleDetailResponse;
@@ -10,6 +11,7 @@ import kr.ai.nemo.schedule.service.ScheduleCommandService;
 import kr.ai.nemo.schedule.service.ScheduleQueryService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -45,5 +47,12 @@ public class ScheduleController {
   public ResponseEntity<ApiResponse<ScheduleDetailResponse>> getScheduleDetail(@PathVariable Long scheduleId) {
     ScheduleDetailResponse response = scheduleQueryService.getScheduleDetail(scheduleId);
     return ResponseEntity.ok(ApiResponse.success(response));
+  }
+
+  @GetMapping("/me")
+  public ResponseEntity<ApiResponse<MySchedulesResponse>> getMySchedules(
+      @AuthenticationPrincipal Long userId
+  ) {
+    return ResponseEntity.ok(ApiResponse.success(scheduleQueryService.getMySchedules(userId)));
   }
 }

--- a/src/main/java/kr/ai/nemo/schedule/dto/MySchedulesResponse.java
+++ b/src/main/java/kr/ai/nemo/schedule/dto/MySchedulesResponse.java
@@ -1,0 +1,45 @@
+package kr.ai.nemo.schedule.dto;
+
+import java.util.List;
+import kr.ai.nemo.schedule.domain.Schedule;
+import kr.ai.nemo.schedule.participants.domain.ScheduleParticipant;
+
+public record MySchedulesResponse(
+    List<ScheduleParticipation> notResponded,
+    List<ScheduleParticipation> respondedOngoing,
+    List<ScheduleParticipation> respondedCompleted
+) {
+
+  public record ScheduleParticipation(
+      ScheduleInfo schedule
+  ) {
+    public static ScheduleParticipation from(ScheduleParticipant participant) {
+      return new ScheduleParticipation(ScheduleInfo.from(participant));
+    }
+  }
+
+  public record ScheduleInfo(
+      Long scheduleId,
+      String groupName,
+      String title,
+      String address,
+      int currentUserCount,
+      String ownerName,
+      String startDate,
+      String status
+  ) {
+    public static ScheduleInfo from(ScheduleParticipant participant) {
+      Schedule schedule = participant.getSchedule();
+      return new ScheduleInfo(
+          schedule.getId(),
+          schedule.getGroup().getName(),
+          schedule.getTitle(),
+          schedule.getAddress(),
+          schedule.getCurrentUserCount(),
+          schedule.getOwner().getNickname(),
+          schedule.getStartAt().toLocalDate().toString(),
+          participant.getStatus().name()
+      );
+    }
+  }
+}

--- a/src/main/java/kr/ai/nemo/schedule/participants/domain/enums/ScheduleParticipantStatus.java
+++ b/src/main/java/kr/ai/nemo/schedule/participants/domain/enums/ScheduleParticipantStatus.java
@@ -3,5 +3,13 @@ package kr.ai.nemo.schedule.participants.domain.enums;
 public enum ScheduleParticipantStatus {
   PENDING,
   ACCEPTED,
-  REJECTED
+  REJECTED;
+
+  public boolean isPending() {
+    return this == PENDING;
+  }
+
+  public boolean isAccepted() {
+    return this == ACCEPTED;
+  }
 }

--- a/src/main/java/kr/ai/nemo/schedule/participants/repository/ScheduleParticipantRepository.java
+++ b/src/main/java/kr/ai/nemo/schedule/participants/repository/ScheduleParticipantRepository.java
@@ -14,4 +14,6 @@ public interface ScheduleParticipantRepository extends JpaRepository<SchedulePar
   boolean existsByScheduleAndUser(Schedule schedule, User user);
 
   Optional<ScheduleParticipant> findByScheduleIdAndUserId(Long scheduleId, Long userId);
+
+  List<ScheduleParticipant> findByUserId(Long userId);
 }


### PR DESCRIPTION
## What
→ 나의 일정(참여 전·참여 중·완료) 목록을 한 번에 조회하는 API를 개발 완료하였습니다.

## Why
→ 사용자가 일정을 하나의 화면에서 전환하며 볼 수 있도록 하기 위함입니다.

## Changes
→ ScheduleParticipant 기반으로 참여 상태별 일정 분류 로직 추가
→ 참여 상태에 따른 응답 DTO 구조 정의 및 매핑
→ ScheduleParticipantsService, ScheduleQueryService에 비즈니스 로직 분산 처리

## Related Issue
→ #48