### PR TITLE
feat: 일정 완료 자동 처리 구현 (#53)

### DIFF
--- a/src/main/java/kr/ai/nemo/config/SchedulerConfig.java
+++ b/src/main/java/kr/ai/nemo/config/SchedulerConfig.java
@@ -1,0 +1,10 @@
+package kr.ai.nemo.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.scheduling.annotation.EnableScheduling;
+
+@Configuration
+@EnableScheduling
+public class SchedulerConfig {
+
+}

--- a/src/main/java/kr/ai/nemo/schedule/domain/Schedule.java
+++ b/src/main/java/kr/ai/nemo/schedule/domain/Schedule.java
@@ -80,4 +80,9 @@ public class Schedule {
     this.status = ScheduleStatus.CANCELED;
     this.deletedAt = LocalDateTime.now();
   }
+
+  public void complete() {
+    this.status = ScheduleStatus.CLOSED;
+    this.deletedAt = LocalDateTime.now();
+  }
 }

--- a/src/main/java/kr/ai/nemo/schedule/repository/ScheduleRepository.java
+++ b/src/main/java/kr/ai/nemo/schedule/repository/ScheduleRepository.java
@@ -1,5 +1,6 @@
 package kr.ai.nemo.schedule.repository;
 
+import java.time.LocalDateTime;
 import java.util.List;
 import kr.ai.nemo.group.domain.Group;
 import kr.ai.nemo.schedule.domain.Schedule;
@@ -15,4 +16,6 @@ public interface ScheduleRepository extends JpaRepository<Schedule, Long> {
   Page<Schedule> findByGroupId(Long groupId, PageRequest pageRequest);
 
   List<Schedule> findByGroupAndStatus(Group group, ScheduleStatus scheduleStatus);
+
+  List<Schedule> findByStartAtBeforeAndStatus(LocalDateTime now, ScheduleStatus scheduleStatus);
 }

--- a/src/main/java/kr/ai/nemo/scheduler/ScheduleStatusUpdater.java
+++ b/src/main/java/kr/ai/nemo/scheduler/ScheduleStatusUpdater.java
@@ -8,7 +8,7 @@ import org.springframework.stereotype.Component;
 @Component
 public class ScheduleStatusUpdater {
 
-  @Scheduled(fixedRateString = "${schedule.update-fixed-rate}")
+  @Scheduled(cron = "0 0/5 * * * *")
   public void updateClosedSchedules() {
     log.info("Scheduler Status Updater: Updating closed schedules");
   }

--- a/src/main/java/kr/ai/nemo/scheduler/ScheduleStatusUpdater.java
+++ b/src/main/java/kr/ai/nemo/scheduler/ScheduleStatusUpdater.java
@@ -1,0 +1,15 @@
+package kr.ai.nemo.scheduler;
+
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@Component
+public class ScheduleStatusUpdater {
+
+  @Scheduled(fixedRateString = "${schedule.update-fixed-rate}")
+  public void updateClosedSchedules() {
+    log.info("Scheduler Status Updater: Updating closed schedules");
+  }
+}

--- a/src/main/java/kr/ai/nemo/scheduler/ScheduleStatusUpdater.java
+++ b/src/main/java/kr/ai/nemo/scheduler/ScheduleStatusUpdater.java
@@ -1,15 +1,35 @@
 package kr.ai.nemo.scheduler;
 
+import java.time.LocalDateTime;
+import java.util.List;
+import kr.ai.nemo.schedule.domain.Schedule;
+import kr.ai.nemo.schedule.domain.enums.ScheduleStatus;
+import kr.ai.nemo.schedule.repository.ScheduleRepository;
+import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
 
 @Slf4j
 @Component
+@RequiredArgsConstructor
 public class ScheduleStatusUpdater {
 
+  private final ScheduleRepository scheduleRepository;
+
   @Scheduled(cron = "0 0/5 * * * *")
+  @Transactional
   public void updateClosedSchedules() {
-    log.info("Scheduler Status Updater: Updating closed schedules");
+    LocalDateTime now = LocalDateTime.now();
+    log.info("[Scheduler] 일정 상태 업데이트 실행 at {}", now);
+
+    List<Schedule> outdatedSchedules = scheduleRepository.findByStartAtBeforeAndStatus(now, ScheduleStatus.RECRUITING);
+
+    for (Schedule schedule : outdatedSchedules) {
+      schedule.complete();
+      schedule.getGroup().addCompleteSchedule();
+      log.info("일정 상태 변경: [{}] → CLOSED", schedule.getId());
+    }
   }
 }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -39,6 +39,3 @@ management:
   endpoint:
     health:
       show-details: never
-
-schedule:
-  update-fixed-rate: 300000

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -39,3 +39,6 @@ management:
   endpoint:
     health:
       show-details: never
+
+schedule:
+  update-fixed-rate: 300000


### PR DESCRIPTION
## What
→ Spring Scheduler를 사용하여 5분마다 일정 상태를 검사하는 기능을 구현하였습니다.

## Why
→ 시작시간이 된 일정은 완료처리가 되어 더이상 신청할 수 없도록 합니다.

## Changes
→ scheduler 패키지가 추가되었습니다.
→ config 파일이 추가 되었습니다.