### PR TITLE
feat: 응답 body 변경

### DIFF
--- a/src/main/java/kr/ai/nemo/group/participants/dto/GroupParticipantDto.java
+++ b/src/main/java/kr/ai/nemo/group/participants/dto/GroupParticipantDto.java
@@ -1,5 +1,6 @@
 package kr.ai.nemo.group.participants.dto;
 
+import kr.ai.nemo.group.participants.domain.GroupParticipants;
 import kr.ai.nemo.user.domain.User;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
@@ -10,9 +11,10 @@ public class GroupParticipantDto {
   private Long userId;
   private String nickname;
   private String profileImageUrl;
+  private String role;
 
-  public static GroupParticipantDto from(User user) {
-    return new GroupParticipantDto(user.getId(), user.getNickname(), user.getProfileImageUrl());
+  public static GroupParticipantDto from(GroupParticipants participants) {
+    User user = participants.getUser();
+    return new GroupParticipantDto(user.getId(), user.getNickname(), user.getProfileImageUrl(), participants.getRole().name());
   }
-
 }

--- a/src/main/java/kr/ai/nemo/group/participants/service/GroupParticipantsService.java
+++ b/src/main/java/kr/ai/nemo/group/participants/service/GroupParticipantsService.java
@@ -59,7 +59,7 @@ public class GroupParticipantsService {
     groupQueryService.findByIdOrThrow(groupId);
     List<GroupParticipants> participants = groupParticipantsRepository.findByGroupIdAndStatus(groupId, Status.JOINED);
     return participants.stream()
-        .map(p -> GroupParticipantDto.from(p.getUser()))
+        .map(GroupParticipantDto::from)
         .toList();
   }
 
@@ -81,5 +81,4 @@ public class GroupParticipantsService {
       throw new CustomException(ResponseCode.NOT_GROUP_MEMBER);
     }
   }
-
 }

--- a/src/main/java/kr/ai/nemo/schedule/repository/ScheduleRepository.java
+++ b/src/main/java/kr/ai/nemo/schedule/repository/ScheduleRepository.java
@@ -14,7 +14,7 @@ import org.springframework.stereotype.Repository;
 @Repository
 public interface ScheduleRepository extends JpaRepository<Schedule, Long> {
 
-  Page<Schedule> findByGroupId(Long groupId, PageRequest pageRequest);
+  Page<Schedule> findByGroupIdAndStatusNot(Long groupId, PageRequest pageRequest, ScheduleStatus scheduleStatus);
 
   List<Schedule> findByGroupAndStatus(Group group, ScheduleStatus scheduleStatus);
 

--- a/src/main/java/kr/ai/nemo/schedule/service/ScheduleQueryService.java
+++ b/src/main/java/kr/ai/nemo/schedule/service/ScheduleQueryService.java
@@ -36,7 +36,7 @@ public class ScheduleQueryService {
 
   public ScheduleListResponse getGroupSchedules(Long groupId, PageRequest pageRequest) {
     groupQueryService.findByIdOrThrow(groupId);
-    Page<Schedule> page = scheduleRepository.findByGroupId(groupId, pageRequest);
+    Page<Schedule> page = scheduleRepository.findByGroupIdAndStatusNot(groupId, pageRequest, ScheduleStatus.CANCELED);
 
     List<ScheduleListResponse.ScheduleSummary> summaries = page.getContent().stream()
         .map(schedule -> new ScheduleListResponse.ScheduleSummary(


### PR DESCRIPTION
## What
→ 모임원 list 반환시 role (MEMBER, LEADER) 상태값을 함께 반환하도록 하였습니다.
→ 취소된 일정은 모임별 일정 list 조회시 제외되도록 하였습니다.

## Why
→ UX 측면을 고려하여 추가하였습니다.

## Changes
→ 모임원 list 반환 DTO의 인자를 User에서 Participants 로 변경하였습니다.
→ JPA 에 StatusNot 쿼리를 추가하였습니다.