### PR TITLE
feat: 도메인 CORS 허용

### DIFF
--- a/src/main/java/kr/ai/nemo/config/CorsConfig.java
+++ b/src/main/java/kr/ai/nemo/config/CorsConfig.java
@@ -13,11 +13,10 @@ public class CorsConfig {
   @Bean
   public CorsConfigurationSource corsConfigurationSource() {
     CorsConfiguration configuration = new CorsConfiguration();
-    configuration.setAllowedOrigins(List.of("http://localhost:3000", "http://localhost:8000"));
+    configuration.setAllowedOrigins(List.of("https://dev.nemo.ai.kr", "http://localhost:3000", "http://localhost:8000"));
     configuration.setAllowedMethods(List.of("GET", "POST", "PUT", "DELETE", "OPTIONS"));
     configuration.setAllowedHeaders(List.of("*"));
     configuration.setAllowCredentials(true);
-
     UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();
     source.registerCorsConfiguration("/**", configuration);
     return source;


### PR DESCRIPTION
## What
→ https:// 네모 도메인의 CORS를 허용합니다.

## Why
→ 도메인에서 접근할 수 있습니다.

## Changes
→CorsConfig 파일 수정하였습니다.