### PR TITLE
feat: 일정 상세 조회 시 response body 변경

### DIFF
--- a/src/main/java/kr/ai/nemo/schedule/dto/ScheduleDetailResponse.java
+++ b/src/main/java/kr/ai/nemo/schedule/dto/ScheduleDetailResponse.java
@@ -10,13 +10,13 @@ public record ScheduleDetailResponse(
     String title,
     String startAt,
     String address,
-    Long ownerId,
+    String ownerName,
     String createdAt,
     String description,
     GroupInfo group,
     List<ParticipantInfo> participants
 ) {
-  public record GroupInfo(Long groupId, String name, int currentUser) {}
+  public record GroupInfo(Long groupId, String name, int currentUserCount, int maxUserCount) {}
 
   public record ParticipantInfo(Long id, UserInfo user, String status) {}
 
@@ -28,13 +28,14 @@ public record ScheduleDetailResponse(
         schedule.getTitle(),
         schedule.getStartAt().format(DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm")),
         schedule.getAddress(),
-        schedule.getOwner().getId(),
+        schedule.getOwner().getNickname(),
         schedule.getCreatedAt().format(DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm")),
         schedule.getDescription(),
         new GroupInfo(
             schedule.getGroup().getId(),
             schedule.getGroup().getName(),
-            schedule.getGroup().getCurrentUserCount()
+            schedule.getGroup().getCurrentUserCount(),
+            schedule.getGroup().getMaxUserCount()
         ),
         participants.stream()
             .map(p -> new ParticipantInfo(


### PR DESCRIPTION
## What
→ 일정 참여자 상세 조회시 출력되는 일정 참여자 list 의 body값을 변경합니다.

## Why
→ UI적인 측면을 고려하였습니다.

## Changes
→ 일정 상세 조회시 일정을 만든 사용자의 ID값이 아닌, nickname이 출력되도록 합니다.
→ 일정 참여자 list 조회시 모임의 maxUserCount값을 추가하였습ㄴ다.