### PR TITLE
feat: ai 서버와의 통신 방식 MVC로 변경

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -30,7 +30,6 @@ val awsSdkVersion = "1.12.700"
 dependencies {
 
 	implementation("org.springframework.boot:spring-boot-starter-web")
-	implementation("org.springframework.boot:spring-boot-starter-webflux")
 	implementation("org.springframework.boot:spring-boot-starter-validation")
 	implementation("org.springframework.boot:spring-boot-starter-data-jpa")
 	implementation("org.springframework.boot:spring-boot-starter-security")

--- a/src/main/java/kr/ai/nemo/common/exception/ResponseCode.java
+++ b/src/main/java/kr/ai/nemo/common/exception/ResponseCode.java
@@ -47,8 +47,8 @@ public enum ResponseCode {
   INTERNAL_SERVER_ERROR("INTERNAL_SERVER_ERROR", "서버 오류가 발생했습니다.", HttpStatus.INTERNAL_SERVER_ERROR),
   AI_SERVER_CONNECTION_FAILED("AI_SERVER_CONNECTION_FAILED", "AI 서버 연결에 실패했습니다.", HttpStatus.INTERNAL_SERVER_ERROR),
   EXTERNAL_API_ERROR("EXTERNAL_API_ERROR", "외부 API 호출 중 오류가 발생했습니다.", HttpStatus.SERVICE_UNAVAILABLE),
-  S3_UPLOAD_FAILED("S3_UPLOAD_FAILED", "이미지 업로드에 실패했습니다.", HttpStatus.INTERNAL_SERVER_ERROR);
-
+  S3_UPLOAD_FAILED("S3_UPLOAD_FAILED", "이미지 업로드에 실패했습니다.", HttpStatus.INTERNAL_SERVER_ERROR),
+  AI_RESPONSE_PARSE_ERROR("AI_RESPONSE_PARSE_ERROR", "AI 서버로부터 받은 응답을 처리할 수 없습니다.", HttpStatus.INTERNAL_SERVER_ERROR);
 
 
   private final String code;

--- a/src/main/java/kr/ai/nemo/group/controller/GroupController.java
+++ b/src/main/java/kr/ai/nemo/group/controller/GroupController.java
@@ -7,10 +7,13 @@ import kr.ai.nemo.group.dto.GroupAiGenerateResponse;
 import kr.ai.nemo.group.dto.GroupCreateRequest;
 import kr.ai.nemo.group.dto.GroupCreateResponse;
 import kr.ai.nemo.group.dto.GroupDetailResponse;
+import kr.ai.nemo.group.dto.GroupGenerateRequest;
+import kr.ai.nemo.group.dto.GroupGenerateResponse;
 import kr.ai.nemo.group.dto.GroupListResponse;
 import kr.ai.nemo.group.dto.GroupSearchRequest;
 import kr.ai.nemo.group.service.AiGroupGenerateClient;
 import kr.ai.nemo.group.service.GroupCommandService;
+import kr.ai.nemo.group.service.GroupGenerateService;
 import kr.ai.nemo.group.service.GroupQueryService;
 import kr.ai.nemo.schedule.dto.PageRequestDto;
 import kr.ai.nemo.schedule.dto.ScheduleListResponse;
@@ -36,16 +39,19 @@ import java.net.URI;
 @Slf4j
 public class GroupController {
 
-  private final AiGroupGenerateClient aiGroupGenerateClient;
+  private final GroupGenerateService groupGenerateService;
   private final GroupCommandService groupCommandService;
   private final GroupQueryService groupQueryService;
   private final ScheduleQueryService scheduleQueryService;
 
   @PostMapping("/ai-generate")
-  public ResponseEntity<ApiResponse<GroupAiGenerateResponse>> generateGroupInfo(@Valid @RequestBody GroupAiGenerateRequest request) {
-    GroupAiGenerateResponse aiResponse = aiGroupGenerateClient.call(request);
-    return ResponseEntity.ok(ApiResponse.success(aiResponse));
+  public ResponseEntity<ApiResponse<GroupGenerateResponse>> generateGroupInfo(
+      @Valid @RequestBody GroupGenerateRequest request
+  ) {
+    GroupGenerateResponse result = groupGenerateService.generate(request);
+    return ResponseEntity.ok(ApiResponse.success(result));
   }
+
 
   @PostMapping
   public ResponseEntity<ApiResponse<GroupCreateResponse>> createGroup(

--- a/src/main/java/kr/ai/nemo/group/dto/GroupAiGenerateRequest.java
+++ b/src/main/java/kr/ai/nemo/group/dto/GroupAiGenerateRequest.java
@@ -1,5 +1,6 @@
 package kr.ai.nemo.group.dto;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 import lombok.AllArgsConstructor;
@@ -21,6 +22,7 @@ public class GroupAiGenerateRequest {
   @NotBlank(message = "기간 선택은 필수입니다.")
   private String period;
 
+  @JsonProperty("isPlanCreated")
   @NotNull(message = "학습계획 생성 여부 선택은 필수입니다.")
   private boolean isPlanCreated;
 }

--- a/src/main/java/kr/ai/nemo/group/dto/GroupAiGenerateRequest.java
+++ b/src/main/java/kr/ai/nemo/group/dto/GroupAiGenerateRequest.java
@@ -25,4 +25,14 @@ public class GroupAiGenerateRequest {
   @JsonProperty("isPlanCreated")
   @NotNull(message = "학습계획 생성 여부 선택은 필수입니다.")
   private boolean isPlanCreated;
+
+  public static GroupAiGenerateRequest from(GroupGenerateRequest req) {
+    return new GroupAiGenerateRequest(
+        req.name(),
+        req.goal(),
+        req.category(),
+        req.period(),
+        req.isPlanCreated()
+    );
+  }
 }

--- a/src/main/java/kr/ai/nemo/group/dto/GroupAiGenerateResponse.java
+++ b/src/main/java/kr/ai/nemo/group/dto/GroupAiGenerateResponse.java
@@ -3,22 +3,14 @@ package kr.ai.nemo.group.dto;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonInclude.Include;
 import java.util.List;
-import lombok.AllArgsConstructor;
 import lombok.Builder;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
-import lombok.Setter;
 
-@Getter
-@Setter
-@NoArgsConstructor
-@AllArgsConstructor
 @Builder
 @JsonInclude(Include.NON_EMPTY)
-public class GroupAiGenerateResponse {
-  private String name;
-  private String summary;
-  private String description;
-  private List<String> tags;
-  private String plan;
-}
+public record GroupAiGenerateResponse(
+    String name,
+    String summary,
+    String description,
+    List<String> tags,
+    String plan
+) {}

--- a/src/main/java/kr/ai/nemo/group/dto/GroupGenerateRequest.java
+++ b/src/main/java/kr/ai/nemo/group/dto/GroupGenerateRequest.java
@@ -1,0 +1,11 @@
+package kr.ai.nemo.group.dto;
+
+public record GroupGenerateRequest(
+    String name,
+    String goal,
+    String category,
+    String location,
+    String period,
+    int maxUserCount,
+    boolean isPlanCreated
+) {}

--- a/src/main/java/kr/ai/nemo/group/dto/GroupGenerateResponse.java
+++ b/src/main/java/kr/ai/nemo/group/dto/GroupGenerateResponse.java
@@ -1,0 +1,33 @@
+package kr.ai.nemo.group.dto;
+
+import java.util.List;
+
+public record GroupGenerateResponse(
+    String name,
+    String goal,
+    String category,
+    String location,
+    String period,
+    int maxUserCount,
+    boolean isPlanCreated,
+    String summary,
+    String description,
+    List<String> tags,
+    String plan
+) {
+  public static GroupGenerateResponse from(GroupGenerateRequest request, GroupAiGenerateResponse ai) {
+    return new GroupGenerateResponse(
+        request.name(),
+        request.goal(),
+        request.category(),
+        request.location(),
+        request.period(),
+        request.maxUserCount(),
+        request.isPlanCreated(),
+        ai.summary(),
+        ai.description(),
+        ai.tags(),
+        ai.plan()
+    );
+  }
+}

--- a/src/main/java/kr/ai/nemo/group/service/AiGroupGenerateClient.java
+++ b/src/main/java/kr/ai/nemo/group/service/AiGroupGenerateClient.java
@@ -1,63 +1,55 @@
 package kr.ai.nemo.group.service;
 
-import java.time.Duration;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import kr.ai.nemo.common.exception.ApiResponse;
 import kr.ai.nemo.common.exception.CustomException;
 import kr.ai.nemo.common.exception.ResponseCode;
 import kr.ai.nemo.group.dto.GroupAiGenerateRequest;
 import kr.ai.nemo.group.dto.GroupAiGenerateResponse;
+import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
-import org.springframework.http.HttpStatusCode;
-import org.springframework.http.MediaType;
-import org.springframework.http.client.reactive.ReactorClientHttpConnector;
+import org.springframework.core.ParameterizedTypeReference;
+import org.springframework.http.*;
 import org.springframework.stereotype.Component;
-import org.springframework.web.reactive.function.client.WebClient;
-import org.springframework.web.reactive.function.client.WebClientResponseException;
-import reactor.core.publisher.Mono;
-import reactor.netty.http.client.HttpClient;
+import org.springframework.web.client.RestTemplate;
 
-
-@Component
 @Slf4j
+@Component
+@RequiredArgsConstructor
 public class AiGroupGenerateClient {
-  private final WebClient webClient;
 
-  public AiGroupGenerateClient(
-      @Value("${ai.service.url:http://localhost:5000}") String baseUrl,
-      @Value("${ai.service.timeout:5000}") int timeout) {
-    this.webClient = WebClient.builder()
-        .baseUrl(baseUrl)
-        .clientConnector(new ReactorClientHttpConnector(
-            HttpClient.create()
-                .responseTimeout(Duration.ofMillis(timeout))
-        ))
-        .build();
-  }
+  private final RestTemplate restTemplate;
+  private final ObjectMapper objectMapper;
+
+  @Value("${ai.service.url:http://localhost:8000}")
+  private String baseUrl;
 
   public GroupAiGenerateResponse call(GroupAiGenerateRequest request) {
-    log.info("AI 모임 정보 생성 요청: {}", request);
     try {
-      return webClient.post()
-          .uri("/ai/v1/groups/information")
-          .contentType(MediaType.APPLICATION_JSON)
-          .bodyValue(request)
-          .retrieve()
-          .onStatus(HttpStatusCode::is4xxClientError, response -> {
-            log.error("AI 서버 클라이언트 오류: {}", response.statusCode());
-            return Mono.error(new CustomException(ResponseCode.INVALID_REQUEST));
-          })
-          .onStatus(HttpStatusCode::is5xxServerError, response -> {
-            log.error("AI 서버 서버 오류: {}", response.statusCode());
-            return Mono.error(new CustomException(ResponseCode.AI_SERVER_CONNECTION_FAILED));
-          })
-          .bodyToMono(GroupAiGenerateResponse.class)
-          .block();
-    } catch (WebClientResponseException e) {
-      log.error("AI 서버 응답 오류: {}", e.getMessage());
-      throw new CustomException(ResponseCode.AI_SERVER_CONNECTION_FAILED);
+      String url = baseUrl + "/ai/v1/groups/information";
+
+      HttpHeaders headers = new HttpHeaders();
+      headers.setContentType(MediaType.APPLICATION_JSON);
+      HttpEntity<GroupAiGenerateRequest> httpEntity = new HttpEntity<>(request, headers);
+
+      ResponseEntity<ApiResponse<GroupAiGenerateResponse>> response = restTemplate.exchange(
+          url,
+          HttpMethod.POST,
+          httpEntity,
+          new ParameterizedTypeReference<>() {}
+      );
+
+      ApiResponse<GroupAiGenerateResponse> body = response.getBody();
+
+      if (body == null || body.getData() == null) {
+        throw new CustomException(ResponseCode.AI_RESPONSE_PARSE_ERROR);
+      }
+
+      return body.getData();
+
     } catch (Exception e) {
-      log.error("AI 모임 정보 생성 중 오류 발생: {}", e.getMessage());
-      throw new CustomException(ResponseCode.INTERNAL_SERVER_ERROR);
+      throw new CustomException(ResponseCode.AI_SERVER_CONNECTION_FAILED);
     }
   }
 }

--- a/src/main/java/kr/ai/nemo/group/service/AiGroupGenerateClient.java
+++ b/src/main/java/kr/ai/nemo/group/service/AiGroupGenerateClient.java
@@ -1,12 +1,10 @@
 package kr.ai.nemo.group.service;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
 import kr.ai.nemo.common.exception.ApiResponse;
 import kr.ai.nemo.common.exception.CustomException;
 import kr.ai.nemo.common.exception.ResponseCode;
 import kr.ai.nemo.group.dto.GroupAiGenerateRequest;
 import kr.ai.nemo.group.dto.GroupAiGenerateResponse;
-import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.core.ParameterizedTypeReference;
@@ -16,14 +14,18 @@ import org.springframework.web.client.RestTemplate;
 
 @Slf4j
 @Component
-@RequiredArgsConstructor
 public class AiGroupGenerateClient {
 
   private final RestTemplate restTemplate;
-  private final ObjectMapper objectMapper;
+  private final String baseUrl;
 
-  @Value("${ai.service.url:http://localhost:8000}")
-  private String baseUrl;
+  public AiGroupGenerateClient(
+      RestTemplate restTemplate,
+      @Value("${ai.service.url:http://localhost:8000}") String baseUrl
+  ) {
+    this.restTemplate = restTemplate;
+    this.baseUrl = baseUrl;
+  }
 
   public GroupAiGenerateResponse call(GroupAiGenerateRequest request) {
     try {

--- a/src/main/java/kr/ai/nemo/group/service/GroupGenerateService.java
+++ b/src/main/java/kr/ai/nemo/group/service/GroupGenerateService.java
@@ -1,0 +1,21 @@
+package kr.ai.nemo.group.service;
+
+import kr.ai.nemo.group.dto.GroupAiGenerateRequest;
+import kr.ai.nemo.group.dto.GroupAiGenerateResponse;
+import kr.ai.nemo.group.dto.GroupGenerateRequest;
+import kr.ai.nemo.group.dto.GroupGenerateResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class GroupGenerateService {
+
+  private final AiGroupGenerateClient aiClient;
+
+  public GroupGenerateResponse generate(GroupGenerateRequest request) {
+    GroupAiGenerateRequest aiRequest = GroupAiGenerateRequest.from(request);
+    GroupAiGenerateResponse aiResponse = aiClient.call(aiRequest);
+    return GroupGenerateResponse.from(request, aiResponse);
+  }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -52,3 +52,7 @@ cloud:
       secret-key: ${CLOUD_AWS_CREDENTIALS_SECRET_KEY}
     region:
       static: ap-northeast-2
+
+ai:
+  service:
+    url: ${AI_SERVICE_URL}


### PR DESCRIPTION
## What
→ AI와의 연동 과정에서 WebFlux가 아닌 Spring MVC 방식으로 변경하였습니다.
→ FE 요구사항 반영하여 모임 정보 생성 request, response 값 변경하였습니다.
    (기존 모임 정보 생성에 필요한 값만을 주고 받는 방식에서 모임 생성에 관한 전체의 값을 주고 받도록 하였습니다.)

## Why
→AI 연동 과정 중 에러가 발생했고, 디버깅 과정에서 WebFlux의 높은 러닝 커브로 인해 대응에 시간이 소요되었습니다. 이번 케이스에서는 WebFlux가 오히려 오버스펙이라고 판단되어, 기존 Spring MVC 방식으로 전환하였습니다.

## Changes
→ WebFlux -> Spring MVC로 변경하였습니다.
→ request, response file이 하나씩 추가되었습니다.