### PR TITLE
feat: refresh token 방식 변경 / 일정 상세 조회 시 status 값 추가

### DIFF
--- a/src/main/java/kr/ai/nemo/auth/controller/OauthController.java
+++ b/src/main/java/kr/ai/nemo/auth/controller/OauthController.java
@@ -1,5 +1,6 @@
 package kr.ai.nemo.auth.controller;
 
+import jakarta.servlet.http.HttpServletResponse;
 import kr.ai.nemo.auth.dto.TokenRefreshResponse;
 import kr.ai.nemo.auth.exception.OAuthErrorCode;
 import kr.ai.nemo.auth.exception.OAuthException;
@@ -8,6 +9,7 @@ import kr.ai.nemo.common.exception.ApiResponse;
 import kr.ai.nemo.user.dto.UserLoginResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.CookieValue;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestHeader;
@@ -24,7 +26,8 @@ public class OauthController {
   public ResponseEntity<ApiResponse<UserLoginResponse>> kakaoLogin(
       @RequestParam(value = "code", required = false) String code,
       @RequestParam(value = "error", required = false) String error,
-      @RequestParam(value = "error_description", required = false) String errorDescription) {
+      @RequestParam(value = "error_description", required = false) String errorDescription,
+      HttpServletResponse response) {
 
     if (error != null) {
       throw new OAuthException(OAuthErrorCode.KAKAO_AUTH_ERROR);
@@ -34,15 +37,13 @@ public class OauthController {
       throw new OAuthException(OAuthErrorCode.CODE_MISSING);
     }
 
-    UserLoginResponse response = oauthService.loginWithKakao(code);
-    return ResponseEntity.ok(ApiResponse.success(response));
+    return ResponseEntity.ok(ApiResponse.success(oauthService.loginWithKakao(code, response)));
   }
 
   @PostMapping("/api/v1/auth/token/refresh")
   public ResponseEntity<ApiResponse<TokenRefreshResponse>> tokenRefresh(
-      @RequestHeader("Authorization") String refreshToken
+      @CookieValue(name = "refresh_token", required = true) String refreshToken
   ) {
-    TokenRefreshResponse response = oauthService.reissueAccessToken(refreshToken);
-    return ResponseEntity.ok(ApiResponse.success(response));
+    return ResponseEntity.ok(ApiResponse.success(oauthService.reissueAccessToken(refreshToken)));
   }
 }

--- a/src/main/java/kr/ai/nemo/group/controller/GroupController.java
+++ b/src/main/java/kr/ai/nemo/group/controller/GroupController.java
@@ -88,7 +88,7 @@ public class GroupController {
       @Valid PageRequestDto pageRequestDto
   ) {
     return ResponseEntity.ok(ApiResponse.success(
-        scheduleQueryService.getGroupSchedules(groupId, pageRequestDto.toPageRequest())
+        scheduleQueryService.getGroupSchedules(groupId, pageRequestDto.toPageRequest("startAt", "desc"))
     ));
   }
 }

--- a/src/main/java/kr/ai/nemo/schedule/controller/ScheduleController.java
+++ b/src/main/java/kr/ai/nemo/schedule/controller/ScheduleController.java
@@ -46,8 +46,7 @@ public class ScheduleController {
 
   @GetMapping("/{scheduleId}")
   public ResponseEntity<ApiResponse<ScheduleDetailResponse>> getScheduleDetail(@PathVariable Long scheduleId) {
-    ScheduleDetailResponse response = scheduleQueryService.getScheduleDetail(scheduleId);
-    return ResponseEntity.ok(ApiResponse.success(response));
+    return ResponseEntity.ok(ApiResponse.success(scheduleQueryService.getScheduleDetail(scheduleId)));
   }
 
   @GetMapping("/me")

--- a/src/main/java/kr/ai/nemo/schedule/dto/PageRequestDto.java
+++ b/src/main/java/kr/ai/nemo/schedule/dto/PageRequestDto.java
@@ -10,16 +10,14 @@ public record PageRequestDto(
     String sort,
     String direction
 ) {
-  public PageRequestDto {
-    if (sort == null || sort.isBlank()) sort = "createdAt";
-    if (direction == null || direction.isBlank()) direction = "desc";
-  }
+  public PageRequest toPageRequest(String defaultSort, String defaultDirection) {
+    String finalSort = (sort == null || sort.isBlank()) ? defaultSort : sort;
+    String finalDirection = (direction == null || direction.isBlank()) ? defaultDirection : direction;
 
-  public PageRequest toPageRequest() {
     return PageRequest.of(
         page,
         size,
-        Sort.by(Sort.Direction.fromString(direction), sort)
+        Sort.by(Sort.Direction.fromString(finalDirection), finalSort)
     );
   }
 }

--- a/src/main/java/kr/ai/nemo/schedule/dto/ScheduleDetailResponse.java
+++ b/src/main/java/kr/ai/nemo/schedule/dto/ScheduleDetailResponse.java
@@ -13,6 +13,7 @@ public record ScheduleDetailResponse(
     String ownerName,
     String createdAt,
     String description,
+    String scheduleStatus,
     GroupInfo group,
     List<ParticipantInfo> participants
 ) {
@@ -31,6 +32,7 @@ public record ScheduleDetailResponse(
         schedule.getOwner().getNickname(),
         schedule.getCreatedAt().format(DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm")),
         schedule.getDescription(),
+        schedule.getStatus().name(),
         new GroupInfo(
             schedule.getGroup().getId(),
             schedule.getGroup().getName(),

--- a/src/main/java/kr/ai/nemo/user/dto/UserDto.java
+++ b/src/main/java/kr/ai/nemo/user/dto/UserDto.java
@@ -14,14 +14,12 @@ public class UserDto {
   private Long userId;
   private String nickname;
   private String profileImageUrl;
-  private int cacheTtl;
 
   public static UserDto from(User user) {
     return UserDto.builder()
         .userId(user.getId())
         .nickname(user.getNickname())
         .profileImageUrl(user.getProfileImageUrl())
-        .cacheTtl(300)
         .build();
   }
 }

--- a/src/main/java/kr/ai/nemo/user/dto/UserLoginResponse.java
+++ b/src/main/java/kr/ai/nemo/user/dto/UserLoginResponse.java
@@ -12,7 +12,5 @@ import lombok.NoArgsConstructor;
 public class UserLoginResponse {
 
   private String accessToken;
-  private String refreshToken;
-  private Long refreshTokenExpiresIn;
   private UserDto user;
 }


### PR DESCRIPTION
## What
→ refresh token 방식 변경
→ 일정 상세 조회 시 status 값 추가

## Why
→ refresh token을 body에 보낼 시 XSS 공격에 취약함.
→ 일정 상세 조회 시 status 값으로 현재 일정 상태를 확인할 수 있음.

## Changes
→ body에서 제외하고, Cookie로 저장하도록 변경