### PR TITLE
feat: 모임 사진 S3에 저장하는 logic 구현

### DIFF
--- a/src/main/java/kr/ai/nemo/group/service/GroupCommandService.java
+++ b/src/main/java/kr/ai/nemo/group/service/GroupCommandService.java
@@ -12,6 +12,7 @@ import kr.ai.nemo.group.participants.domain.enums.Role;
 import kr.ai.nemo.group.participants.domain.enums.Status;
 import kr.ai.nemo.group.participants.service.GroupParticipantsService;
 import kr.ai.nemo.group.repository.GroupRepository;
+import kr.ai.nemo.image.service.ImageService;
 import kr.ai.nemo.user.domain.User;
 import kr.ai.nemo.user.service.UserQueryService;
 import lombok.RequiredArgsConstructor;
@@ -26,6 +27,7 @@ public class GroupCommandService {
   private final UserQueryService userQueryService;
   private final GroupTagService groupTagService;
   private final GroupParticipantsService groupParticipantsService;
+  private final ImageService imageService;
 
   @Transactional
   public GroupCreateResponse createGroup(@Valid GroupCreateRequest request, Long userId) {
@@ -44,7 +46,7 @@ public class GroupCommandService {
         .category(request.getCategory())
         .location(request.getLocation())
         .completedScheduleTotal(0)
-        .imageUrl(request.getImageUrl())
+        .imageUrl(imageService.uploadGroupImage(request.getImageUrl()))
         .currentUserCount(0)
         .maxUserCount(request.getMaxUserCount())
         .status(GroupStatus.ACTIVE)

--- a/src/main/java/kr/ai/nemo/image/service/ImageService.java
+++ b/src/main/java/kr/ai/nemo/image/service/ImageService.java
@@ -36,4 +36,19 @@ public class ImageService {
       throw new CustomException(ResponseCode.S3_UPLOAD_FAILED);
     }
   }
+
+  public String uploadGroupImage(String imageUrl) {
+    try (InputStream inputStream = URI.create(imageUrl).toURL().openStream()) {
+      String fileName = String.format("groups/profile_%s.jpg", UUID.randomUUID());
+
+      ObjectMetadata metadata = new ObjectMetadata();
+      metadata.setContentType("image/jpeg");
+
+      amazonS3.putObject(bucket, fileName, inputStream, metadata);
+
+      return amazonS3.getUrl(bucket, fileName).toString();
+    } catch (IOException e) {
+      throw new CustomException(ResponseCode.S3_UPLOAD_FAILED);
+    }
+  }
 }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -3,9 +3,9 @@ spring:
     name: nemo
 
   datasource:
-    url: jdbc:mysql://${db_url}?serverTimezone=Asia/Seoul&characterEncoding=UTF-8
-    username: ${username}
-    password: ${password}
+    url: jdbc:mysql://${DB_URL}?serverTimezone=Asia/Seoul&characterEncoding=UTF-8
+    username: ${USERNAME}
+    password: ${PASSWORD}
     driver-class-name: com.mysql.cj.jdbc.Driver
 
   jpa:
@@ -46,12 +46,12 @@ server:
 cloud:
   aws:
     s3:
-      bucket: ${BUCKET-NAME}
+      bucket: ${BUCKET_NAME}
     credentials:
       access-key: ${CLOUD_AWS_CREDENTIALS_ACCESS_KEY}
       secret-key: ${CLOUD_AWS_CREDENTIALS_SECRET_KEY}
     region:
-      static: ap-northeast-2
+      static: ${AWS_REGION}
 
 ai:
   service:


### PR DESCRIPTION
## What
→ 모임 관련 사진을 S3에 저장하도록 합니다.

## Why
→ 모임 생성시 대표 사진을 S3에 등록하여 이미지 url을 유지합니다.

## Changes
→ image Service 내 group으로 들어가는 logic 추가

## Related Issue
→ #77 