### PR TITLE
feat: access token 반환 방식 변경 (#79)

### DIFF
--- a/src/main/java/kr/ai/nemo/auth/controller/OauthController.java
+++ b/src/main/java/kr/ai/nemo/auth/controller/OauthController.java
@@ -27,9 +27,9 @@ public class OauthController {
       @RequestParam(value = "code", required = false) String code,
       @RequestParam(value = "error", required = false) String error,
       HttpServletResponse response) {
-    oauthService.handleKakaoCallback(code, error, response);
+    String accessToken = oauthService.handleKakaoCallback(code, error, response);
     try {
-      response.sendRedirect(UriGenerator.login().toString());
+      response.sendRedirect(UriGenerator.login(accessToken).toString());
     } catch (IOException e) {
       throw new CustomException(ResponseCode.REDIRECT_FAIL);
     }

--- a/src/main/java/kr/ai/nemo/common/UriGenerator.java
+++ b/src/main/java/kr/ai/nemo/common/UriGenerator.java
@@ -8,7 +8,7 @@ public class UriGenerator {
     return URI.create(String.format("https://dev.nemo.ai.kr/api/v1/schedules/%d", scheduleId));
   }
 
-  public static URI login() {
-    return URI.create("https://dev.nemo.ai.kr/login");
+  public static URI login(String accessToken) {
+    return URI.create("https://dev.nemo.ai.kr/login?token=" + accessToken);
   }
 }


### PR DESCRIPTION
## What
→ access token 반환 방식 변경 완료하였습니다.

## Why
→ OAuth2 로그인 시 302 redirect로 body를 반환할 수 없기 때문에 파라미터로 전달되도록 하였습니다.

## Changes
→ URI 수정

## Related Issue
→ #77 