### PR TITLE
feat: oauth 동작 방식 변경 (#84)

### DIFF
--- a/src/main/java/kr/ai/nemo/common/UriGenerator.java
+++ b/src/main/java/kr/ai/nemo/common/UriGenerator.java
@@ -1,14 +1,35 @@
 package kr.ai.nemo.common;
 
 import java.net.URI;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+import org.springframework.web.util.UriComponentsBuilder;
 
+@Component
 public class UriGenerator {
+
+  @Value("${oauth.kakao.rest-api-key}")
+  private String restApiKey;
+
+  @Value("${oauth.kakao.redirect-uri}")
+  private String redirectUri;
 
   public static URI scheduleDetail(Long scheduleId) {
     return URI.create(String.format("https://dev.nemo.ai.kr/api/v1/schedules/%d", scheduleId));
   }
 
-  public static URI login(String accessToken) {
-    return URI.create("https://dev.nemo.ai.kr/login?token=" + accessToken);
+  public URI kakaoLogin(String state) {
+    return UriComponentsBuilder
+        .fromUriString("https://kauth.kakao.com/oauth/authorize")
+        .queryParam("response_type", "code")
+        .queryParam("client_id", restApiKey)
+        .queryParam("redirect_uri", redirectUri)
+        .queryParam("state", state)
+        .build()
+        .toUri();
+  }
+
+  public URI login(String state, String accessToken) {
+    return URI.create(state + "?token=" + accessToken);
   }
 }

--- a/src/main/java/kr/ai/nemo/config/SecurityConfig.java
+++ b/src/main/java/kr/ai/nemo/config/SecurityConfig.java
@@ -30,7 +30,7 @@ public class SecurityConfig {
         .csrf(AbstractHttpConfigurer::disable)
         .authorizeHttpRequests(auth -> auth
             .requestMatchers("/auth/**").permitAll()
-            .requestMatchers(HttpMethod.GET, "/api/v1/auth/*").permitAll()
+            .requestMatchers(HttpMethod.GET, "/api/v1/auth/**").permitAll()
             .requestMatchers(HttpMethod.GET, "/api/v1/groups/me").authenticated()
             .requestMatchers(HttpMethod.GET, "/api/v1/groups/**").permitAll()
             .requestMatchers(HttpMethod.GET, "/api/v1/schedules/**").permitAll()


### PR DESCRIPTION
## What
→ OAuth 로그인 플로우를 수정합니다.

## Why
→ 기존에는 카카오 로그인 이후 리디렉션되는 URI가 고정되어 있어,
→ 프론트엔드 로컬 환경에서 테스트가 어렵고
→ 인스턴스마다 환경변수를 설정해야 하는 불편함이 있었습니다.

## Changes
→ 프론트엔드가 백엔드의 로그인 API(`/api/v1/login/kakao`)에 `redirect_uri` 파라미터를 포함하여 요청
→ 백엔드는 해당 redirect URI를 OAuth `state` 파라미터로 포함해 카카오 인증 페이지로 리디렉션
→ 인증 완료 후, 백엔드는 전달받은 `state` 값을 기반으로 최종 redirect 처리 및 토큰 전달

## Related Issue
→ Closes #84
