### PR TITLE
fix: 해체된 모임은 list 조회 불가

### DIFF
--- a/src/main/java/kr/ai/nemo/group/repository/GroupRepository.java
+++ b/src/main/java/kr/ai/nemo/group/repository/GroupRepository.java
@@ -1,8 +1,10 @@
 package kr.ai.nemo.group.repository;
 
 import kr.ai.nemo.group.domain.Group;
+import kr.ai.nemo.group.domain.enums.GroupStatus;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
@@ -10,10 +12,16 @@ import org.springframework.stereotype.Repository;
 
 @Repository
 public interface GroupRepository extends JpaRepository<Group, Long> {
-  @Query("SELECT g FROM Group g WHERE g.name LIKE %:keyword% OR g.summary LIKE %:keyword%")
+  @Query("SELECT g FROM Group g " +
+      "WHERE g.status <> 'DISBANDED' AND " +
+      "(g.name LIKE %:keyword% OR g.summary LIKE %:keyword%)")
   Page<Group> searchWithKeywordOnly(@Param("keyword") String keyword, Pageable pageable);
 
-  Page<Group> findByCategory(String category, Pageable pageable);
+  @EntityGraph(attributePaths = {"groupTags", "groupTags.tag"})
+  Page<Group> findByCategoryAndStatusNot(String category, GroupStatus status, Pageable pageable);
+
+  @EntityGraph(attributePaths = {"groupTags", "groupTags.tag"})
+  Page<Group> findByStatusNot(GroupStatus status, Pageable pageable);
 
   Group getGroupById(Long id);
 }

--- a/src/main/java/kr/ai/nemo/group/service/GroupQueryService.java
+++ b/src/main/java/kr/ai/nemo/group/service/GroupQueryService.java
@@ -32,11 +32,11 @@ public class GroupQueryService {
     Page<Group> groups;
 
     if (request.getCategory() != null) {
-      groups = groupRepository.findByCategory(request.getCategory(), pageable);
+      groups = groupRepository.findByCategoryAndStatusNot(request.getCategory(), GroupStatus.DISBANDED, pageable);
     } else if (request.getKeyword() != null && !request.getKeyword().isBlank()) {
       groups = groupRepository.searchWithKeywordOnly(request.getKeyword(), pageable);
     } else {
-      groups = groupRepository.findAll(pageable);
+      groups = groupRepository.findByStatusNot(GroupStatus.DISBANDED, pageable);
     }
 
     Page<GroupDto> groupDtoPage = groups.map(GroupDto::from);


### PR DESCRIPTION
## What
> 무엇을 작업했는지 간결하게 적습니다.

→ 모임 list 출력 시 해체된 모임도 출력되는 에러 수정

## Why
> 왜 이 작업을 했는지 설명합니다.

→ 해체된 모임을 사용자에게 출력하면 혼란을 야기할 수 있습니다.

## Changes
> 주요 변경사항을 적습니다.

→ JPA Query를 수정하였습니다.