### PR TITLE
infra: 운영 서버용 CI/CD 워크플로우 분리 및 추가

### DIFF
--- a/.github/workflows/cd-v1-prod.yaml
+++ b/.github/workflows/cd-v1-prod.yaml
@@ -1,0 +1,21 @@
+name: Backend CD for prod-v1
+
+on:
+  workflow_dispatch:
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    environment:
+      name: prod
+
+    steps:
+      - name: Deploy to Prod Server
+        uses: appleboy/ssh-action@v1.0.3
+        with:
+          host: ${{ secrets.PROD_HOST }}
+          username: ${{ secrets.PROD_USER }}
+          key: ${{ secrets.PROD_SSH_KEY }}
+          script: |
+            cd ~/nemo/backend/scripts
+            bash deploy_ci_cd.sh

--- a/.github/workflows/ci-v1-prod.yaml
+++ b/.github/workflows/ci-v1-prod.yaml
@@ -25,5 +25,7 @@ jobs:
 
       - name: Upload JAR to Prod Server
         run: |
+          echo "${{ secrets.DEV_SSH_KEY }}" > temp_key
+          chmod 600 temp_key
           scp -i temp_key -o StrictHostKeyChecking=no ./build/libs/nemo-server-0.0.1-SNAPSHOT.jar \
           ${{ secrets.PROD_USER }}@${{ secrets.PROD_HOST }}:~/nemo/backend/jar-backups/

--- a/.github/workflows/ci-v1-prod.yaml
+++ b/.github/workflows/ci-v1-prod.yaml
@@ -1,0 +1,29 @@
+name: Backend CI for prod-v1
+
+on:
+  push:
+    branches: [ main ]
+
+jobs:
+  build-and-upload:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout Code
+        uses: actions/checkout@v3
+
+      - name: Set up JDK 21
+        uses: actions/setup-java@v3
+        with:
+          java-version: '21'
+          distribution: 'temurin'
+
+      - name: Build with Gradle
+        run: |
+          chmod +x ./gradlew
+          ./gradlew clean bootJar -x test
+
+      - name: Upload JAR to Prod Server
+        run: |
+          scp -i temp_key -o StrictHostKeyChecking=no ./build/libs/nemo-server-0.0.1-SNAPSHOT.jar \
+          ${{ secrets.PROD_USER }}@${{ secrets.PROD_HOST }}:~/nemo/backend/jar-backups/

--- a/.github/workflows/cicd-v1-dev.yaml
+++ b/.github/workflows/cicd-v1-dev.yaml
@@ -2,7 +2,7 @@ name: Backend CI/CD for dev-v1
 
 on:
   push:
-    branches: [ develop, infra/ci-cd ]
+    branches: [ develop ]
 
 jobs:
   build-and-deploy:
@@ -25,6 +25,8 @@ jobs:
 
       - name: Upload JAR to Server
         run: |
+          echo "${{ secrets.DEV_SSH_KEY }}" > temp_key
+          chmod 600 temp_key
           scp -i temp_key -o StrictHostKeyChecking=no ./build/libs/nemo-server-0.0.1-SNAPSHOT.jar \
           ${{ secrets.DEV_USER }}@${{ secrets.DEV_HOST }}:~/nemo/backend/jar-backups/
 

--- a/.github/workflows/cicd-v1-dev.yaml
+++ b/.github/workflows/cicd-v1-dev.yaml
@@ -25,8 +25,6 @@ jobs:
 
       - name: Upload JAR to Server
         run: |
-          echo "${{ secrets.DEV_SSH_KEY }}" > temp_key
-          chmod 600 temp_key
           scp -i temp_key -o StrictHostKeyChecking=no ./build/libs/nemo-server-0.0.1-SNAPSHOT.jar \
           ${{ secrets.DEV_USER }}@${{ secrets.DEV_HOST }}:~/nemo/backend/jar-backups/
 
@@ -39,4 +37,3 @@ jobs:
           script: |
             cd ~/nemo/backend/scripts
             bash deploy_ci_cd.sh
-# ci/cd test


### PR DESCRIPTION
## What
> 무엇을 작업했는지 간결하게 적습니다.

운영(prod) 환경 전용 CI/CD 워크플로우를 개발용 워크플로우와 분리하여 추가하였습니다.

- `ci-prod.yaml`  
  - main 브랜치 푸시 시 자동 빌드 및 운영 서버로 JAR 업로드
- `cd-prod.yaml`  
  - GitHub Actions → workflow_dispatch → 수동 승인 후 배포 스크립트 실행

## Why
> 왜 이 작업을 했는지 설명합니다.
- 운영 배포는 수동 승인이 필요한 플로우로 구분되어야 하며, main 브랜치 기준으로 분기되므로 dev 환경과 분리
- 실수로 운영 배포가 자동 실행되는 것을 방지하기 위함

## Changes
> 주요 변경사항을 적습니다.
- `.github/workflows/ci-prod.yaml` 추가
- `.github/workflows/cd-prod.yaml` 추가

## Notes
> 참고 내용을 적습니다.
- 다음 시크릿이 GitHub에 등록
  - `PROD_SSH_KEY`
  - `PROD_USER`
  - `PROD_HOST`
- 운영 서버 내 경로: `~/nemo/backend/jar-backups/`, `~/nemo/backend/scripts/deploy_ci_cd.sh` 필요

## Related
> 관련 이슈 번호를 연결합니다.
