### PR TITLE
transactional 적용 및 DB 쿼리 개선

### DIFF
--- a/src/main/java/kr/ai/nemo/domain/auth/controller/AuthController.java
+++ b/src/main/java/kr/ai/nemo/domain/auth/controller/AuthController.java
@@ -49,7 +49,7 @@ public class AuthController {
       @RequestParam(value = "code", required = false) String code,
       @RequestParam(value = "error", required = false) String error,
       HttpServletResponse response) {
-    String accessToken = oauthService.handleKakaoCallback(code, error, response);
+    String accessToken = oauthService.loginWithKakao(code, error, response);
     try {
       response.sendRedirect(uriGenerator.login(state, accessToken).toString());
     } catch (IOException e) {

--- a/src/main/java/kr/ai/nemo/domain/auth/service/OauthService.java
+++ b/src/main/java/kr/ai/nemo/domain/auth/service/OauthService.java
@@ -69,22 +69,7 @@ public class OauthService {
     return tokenManager.reissueAccessToken(refreshToken);
   }
 
-<<<<<<< HEAD
-  public String handleKakaoCallback(String code, String error, HttpServletResponse response) {
-    if (error != null) {
-      throw new AuthException(KakaoOAuthErrorCode.KAKAO_AUTH_ERROR);
-    }
-
-    if (code == null || code.isEmpty()) {
-      throw new AuthException(KakaoOAuthErrorCode.CODE_MISSING);
-    }
-
-    return loginWithKakao(code, response);
-  }
-
   @TimeTrace
-=======
->>>>>>> 7ffc18e (fix: transactional 적용을 위한 로그인 flow 변경 (#114))
   @Transactional
   public void invalidateRefreshToken(String refreshToken) {
     userTokenService.revokeToken(refreshToken);

--- a/src/main/java/kr/ai/nemo/domain/auth/service/OauthService.java
+++ b/src/main/java/kr/ai/nemo/domain/auth/service/OauthService.java
@@ -25,7 +25,14 @@ public class OauthService {
 
   @TimeTrace
   @Transactional
-  public String loginWithKakao(String code, HttpServletResponse response) {
+  public String loginWithKakao(String code, String error, HttpServletResponse response) {
+    if (error != null) {
+      throw new AuthException(KakaoOAuthErrorCode.KAKAO_AUTH_ERROR);
+    }
+
+    if (code == null || code.isEmpty()) {
+      throw new AuthException(KakaoOAuthErrorCode.CODE_MISSING);
+    }
     try {
       KakaoTokenResponse kakaoToken = kakaoClient.getAccessToken(code);
       if (kakaoToken.accessToken() == null || kakaoToken.accessToken().isEmpty()) {
@@ -62,6 +69,7 @@ public class OauthService {
     return tokenManager.reissueAccessToken(refreshToken);
   }
 
+<<<<<<< HEAD
   public String handleKakaoCallback(String code, String error, HttpServletResponse response) {
     if (error != null) {
       throw new AuthException(KakaoOAuthErrorCode.KAKAO_AUTH_ERROR);
@@ -75,6 +83,8 @@ public class OauthService {
   }
 
   @TimeTrace
+=======
+>>>>>>> 7ffc18e (fix: transactional 적용을 위한 로그인 flow 변경 (#114))
   @Transactional
   public void invalidateRefreshToken(String refreshToken) {
     userTokenService.revokeToken(refreshToken);

--- a/src/main/java/kr/ai/nemo/domain/group/controller/GroupController.java
+++ b/src/main/java/kr/ai/nemo/domain/group/controller/GroupController.java
@@ -29,6 +29,8 @@ import kr.ai.nemo.global.swagger.group.SwaggerScheduleListResponse;
 import kr.ai.nemo.global.swagger.jwt.SwaggerJwtErrorResponse;
 import kr.ai.nemo.global.swagger.group.SwaggerGroupListResponse;
 import lombok.RequiredArgsConstructor;
+import org.springdoc.core.annotations.ParameterObject;
+import org.springframework.data.domain.PageRequest;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -57,8 +59,9 @@ public class GroupController {
   @ApiResponse(responseCode = "200", description = "성공적으로 조회되었습니다.", content = @Content(schema = @Schema(implementation = SwaggerGroupListResponse.class)))
   @TimeTrace
   @GetMapping
-  public ResponseEntity<BaseApiResponse<GroupListResponse>> getGroups(@Valid @ModelAttribute GroupSearchRequest request) {
-    return ResponseEntity.ok(BaseApiResponse.success(groupQueryService.getGroups(request)));
+  public ResponseEntity<BaseApiResponse<GroupListResponse>> getGroups(@Valid @ModelAttribute GroupSearchRequest request, @ParameterObject @Valid PageRequestDto pageRequestDto) {
+    PageRequest pageRequest = pageRequestDto.toPageRequest("createAt", "desc");
+    return ResponseEntity.ok(BaseApiResponse.success(groupQueryService.getGroups(request, pageRequest)));
   }
 
   @Operation(summary = "모임 상세 조회", description = "요청한 모임의 상세 정보를 조회합니다.")
@@ -73,8 +76,9 @@ public class GroupController {
   @ApiResponse(responseCode = "200", description = "성공적으로 조회되었습니다.", content = @Content(schema = @Schema(implementation = SwaggerGroupListResponse.class)))
   @TimeTrace
   @GetMapping("/search")
-  public ResponseEntity<BaseApiResponse<GroupListResponse>> searchGroups(@Valid @ModelAttribute GroupSearchRequest request) {
-    return ResponseEntity.ok(BaseApiResponse.success(groupQueryService.getGroups(request)));
+  public ResponseEntity<BaseApiResponse<GroupListResponse>> searchGroups(@Valid @ModelAttribute GroupSearchRequest request, @ParameterObject @Valid PageRequestDto pageRequestDto) {
+    PageRequest pageRequest = pageRequestDto.toPageRequest("", "desc");
+    return ResponseEntity.ok(BaseApiResponse.success(groupQueryService.getGroups(request, pageRequest)));
   }
 
   @Operation(summary = "모임의 일정 리스트 조회", description = "특정 모임의 일정 리스트를 조회합니다.")

--- a/src/main/java/kr/ai/nemo/domain/group/repository/GroupRepository.java
+++ b/src/main/java/kr/ai/nemo/domain/group/repository/GroupRepository.java
@@ -12,14 +12,13 @@ import org.springframework.stereotype.Repository;
 
 @Repository
 public interface GroupRepository extends JpaRepository<Group, Long> {
+  @EntityGraph(attributePaths = {"groupTags", "groupTags.tag"})
   @Query("""
-      SELECT DISTINCT g FROM Group g
- LEFT JOIN g.groupTags t
- WHERE g.status <> 'DISBANDED' AND (
-     g.name LIKE %:keyword% OR
-     g.summary LIKE %:keyword% OR
-     t.tag.name LIKE %:keyword%
- )
+    SELECT DISTINCT g FROM Group g
+    WHERE g.status <> 'DISBANDED' AND (
+        g.name LIKE %:keyword% OR
+        g.summary LIKE %:keyword%
+    )
 """)
   Page<Group> searchWithKeywordOnly(@Param("keyword") String keyword, Pageable pageable);
 

--- a/src/main/java/kr/ai/nemo/domain/group/repository/GroupTagRepository.java
+++ b/src/main/java/kr/ai/nemo/domain/group/repository/GroupTagRepository.java
@@ -2,11 +2,13 @@ package kr.ai.nemo.domain.group.repository;
 
 import java.util.List;
 import kr.ai.nemo.domain.group.domain.GroupTag;
+import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
 @Repository
 public interface GroupTagRepository extends JpaRepository<GroupTag, Long> {
 
+  @EntityGraph(attributePaths = {"tag"})
   List<GroupTag> findByGroupId(Long groupId);
 }

--- a/src/main/java/kr/ai/nemo/domain/group/service/GroupQueryService.java
+++ b/src/main/java/kr/ai/nemo/domain/group/service/GroupQueryService.java
@@ -13,9 +13,7 @@ import kr.ai.nemo.domain.group.validator.GroupValidator;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.Page;
-import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
-import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -29,10 +27,8 @@ public class GroupQueryService {
   private final GroupValidator groupValidator;
   private final GroupTagService groupTagService;
 
-  @TimeTrace
-  public GroupListResponse getGroups(GroupSearchRequest request) {
-    Pageable pageable = toPageable(request);
-
+  @Transactional(readOnly = true)
+  public GroupListResponse getGroups(GroupSearchRequest request, Pageable pageable) {
     Page<Group> groups;
 
     if (request.getCategory() != null) {
@@ -49,14 +45,10 @@ public class GroupQueryService {
   }
 
   @TimeTrace
+  @Transactional(readOnly = true)
   public GroupDetailResponse detailGroup(Long groupId) {
     Group group = groupValidator.findByIdOrThrow(groupId);
     List<String> tags = groupTagService.getTagNamesByGroupId(group.getId());
     return GroupDetailResponse.from(group, tags);
-  }
-
-  private Pageable toPageable(GroupSearchRequest request) {
-    Sort sort = Sort.by(Sort.Direction.fromString(request.getDirection()), request.getSort());
-    return PageRequest.of(request.getPage(), request.getSize(), sort);
   }
 }

--- a/src/main/java/kr/ai/nemo/domain/groupparticipants/service/GroupParticipantsQueryService.java
+++ b/src/main/java/kr/ai/nemo/domain/groupparticipants/service/GroupParticipantsQueryService.java
@@ -11,6 +11,7 @@ import kr.ai.nemo.domain.groupparticipants.dto.response.MyGroupDto;
 import kr.ai.nemo.domain.groupparticipants.repository.GroupParticipantsRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 @RequiredArgsConstructor
 @Service
@@ -20,6 +21,7 @@ public class GroupParticipantsQueryService {
   private final GroupValidator groupValidator;
 
   @TimeTrace
+  @Transactional(readOnly = true)
   public List<GroupParticipantsListResponse.GroupParticipantDto> getAcceptedParticipants(Long groupId) {
     groupValidator.findByIdOrThrow(groupId);
     return groupParticipantsRepository.findByGroupIdAndStatus(groupId, Status.JOINED).stream()
@@ -28,6 +30,7 @@ public class GroupParticipantsQueryService {
   }
 
   @TimeTrace
+  @Transactional(readOnly = true)
   public List<MyGroupDto> getMyGroups(Long userId) {
     List<GroupParticipants> participants = groupParticipantsRepository.findByUserIdAndStatus(userId, Status.JOINED);
 

--- a/src/main/java/kr/ai/nemo/domain/schedule/service/ScheduleQueryService.java
+++ b/src/main/java/kr/ai/nemo/domain/schedule/service/ScheduleQueryService.java
@@ -20,6 +20,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @RequiredArgsConstructor
@@ -30,6 +31,7 @@ public class ScheduleQueryService {
   private final ScheduleValidator scheduleValidator;
 
   @TimeTrace
+  @Transactional(readOnly = true)
   public ScheduleDetailResponse getScheduleDetail(Long scheduleId) {
     Schedule schedule = scheduleValidator.findByIdOrThrow(scheduleId);
 
@@ -38,6 +40,7 @@ public class ScheduleQueryService {
   }
 
   @TimeTrace
+  @Transactional(readOnly = true)
   public ScheduleListResponse getGroupSchedules(Long groupId, PageRequest pageRequest) {
     groupValidator.findByIdOrThrow(groupId);
     Page<Schedule> page = scheduleRepository.findByGroupIdAndStatusNot(groupId, pageRequest, ScheduleStatus.CANCELED);
@@ -66,6 +69,7 @@ public class ScheduleQueryService {
   }
 
   @TimeTrace
+  @Transactional(readOnly = true)
   public MySchedulesResponse getMySchedules(Long userId) {
     List<ScheduleParticipant> participants = scheduleParticipantRepository.findByUserId(userId);
 

--- a/src/main/java/kr/ai/nemo/domain/scheduleparticipants/repository/ScheduleParticipantRepository.java
+++ b/src/main/java/kr/ai/nemo/domain/scheduleparticipants/repository/ScheduleParticipantRepository.java
@@ -7,6 +7,7 @@ import kr.ai.nemo.domain.scheduleparticipants.domain.ScheduleParticipant;
 import kr.ai.nemo.domain.user.domain.User;
 import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 
 public interface ScheduleParticipantRepository extends JpaRepository<ScheduleParticipant, Long> {
 
@@ -17,5 +18,12 @@ public interface ScheduleParticipantRepository extends JpaRepository<SchedulePar
 
   Optional<ScheduleParticipant> findByScheduleIdAndUserId(Long scheduleId, Long userId);
 
+  @Query("""
+    SELECT sp FROM ScheduleParticipant sp
+    LEFT JOIN FETCH sp.schedule s
+    LEFT JOIN FETCH s.group g
+    LEFT JOIN FETCH s.owner o
+    WHERE sp.user.id = :userId
+""")
   List<ScheduleParticipant> findByUserId(Long userId);
 }

--- a/src/main/java/kr/ai/nemo/domain/scheduleparticipants/repository/ScheduleParticipantRepository.java
+++ b/src/main/java/kr/ai/nemo/domain/scheduleparticipants/repository/ScheduleParticipantRepository.java
@@ -5,10 +5,12 @@ import java.util.Optional;
 import kr.ai.nemo.domain.schedule.domain.Schedule;
 import kr.ai.nemo.domain.scheduleparticipants.domain.ScheduleParticipant;
 import kr.ai.nemo.domain.user.domain.User;
+import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface ScheduleParticipantRepository extends JpaRepository<ScheduleParticipant, Long> {
 
+  @EntityGraph(attributePaths = {"user"})
   List<ScheduleParticipant> findByScheduleId(Long scheduleId);
 
   boolean existsByScheduleAndUser(Schedule schedule, User user);


### PR DESCRIPTION
## What
> 무엇을 작업했는지 간결하게 적습니다.

→ service 내 DB에 접근하는 모든 logic에 transactional을 적용하였습니다.
→ DB를 조회하는 logic에는 readOnly=true를 적용하였습니다.
→ 조회하는 API 내 DB 조회 쿼리를 JPA가 하는 것이 아닌, 직접 작성하여 N+1 문제를 개선하였습니다.

## Why
> 왜 이 작업을 했는지 설명합니다.

→ N+1 문제로 CPU가 튀어 서버가 다운되는 현상이 발생하였고, 이 문제를 줄이기 위해 개선하였습니다.

## Changes
> 주요 변경사항을 적습니다.

→ service 로직에 transactional을 적용하고, N+1 문제를 개선하여 API 성능을 개선하였습니다.

## Related Issue
> 관련 이슈 번호를 연결합니다.

→ #114 #115 