### PR TITLE
모임원 추방, 모임 탈퇴 API 구현

### DIFF
--- a/src/main/java/kr/ai/nemo/domain/group/domain/Group.java
+++ b/src/main/java/kr/ai/nemo/domain/group/domain/Group.java
@@ -112,6 +112,10 @@ public class Group {
     this.currentUserCount++;
   }
 
+  public void decreaseCurrentUserCount() {
+    this.currentUserCount--;
+  }
+
   public void addCompleteSchedule() {
     this.completedScheduleTotal++;
   }

--- a/src/main/java/kr/ai/nemo/domain/group/exception/GroupErrorCode.java
+++ b/src/main/java/kr/ai/nemo/domain/group/exception/GroupErrorCode.java
@@ -13,6 +13,9 @@ public enum GroupErrorCode implements ErrorCode {
   // 400 BAD REQUEST
   INVALID_CATEGORY("INVALID_CATEGOTY","올바르지 않은 모임 카테고리입니다.", HttpStatus.BAD_REQUEST ),
 
+  // 403 Forbidden
+  NOT_GROUP_OWNER("GROUP_KICK_FORBIDDEN", "추방 권한이 없습니다.", HttpStatus.FORBIDDEN),
+
   // 404 NOT FOUND
   GROUP_NOT_FOUND("GROUP_NOT_FOUND", "모임을 찾을 수 없습니다.", HttpStatus.NOT_FOUND),
 

--- a/src/main/java/kr/ai/nemo/domain/group/repository/GroupRepository.java
+++ b/src/main/java/kr/ai/nemo/domain/group/repository/GroupRepository.java
@@ -2,6 +2,7 @@ package kr.ai.nemo.domain.group.repository;
 
 import kr.ai.nemo.domain.group.domain.Group;
 import kr.ai.nemo.domain.group.domain.enums.GroupStatus;
+import kr.ai.nemo.domain.groupparticipants.domain.enums.Role;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.EntityGraph;
@@ -30,4 +31,6 @@ public interface GroupRepository extends JpaRepository<Group, Long> {
 
   @EntityGraph(attributePaths = {"groupTags", "groupTags.tag"})
   Page<Group> findByStatusNot(GroupStatus status, Pageable pageable);
+
+  boolean existsByIdAndOwnerId(Long groupId, Long userId);
 }

--- a/src/main/java/kr/ai/nemo/domain/group/validator/GroupValidator.java
+++ b/src/main/java/kr/ai/nemo/domain/group/validator/GroupValidator.java
@@ -37,10 +37,11 @@ public class GroupValidator {
     }
   }
 
-  public void isOwner(Long groupId, Long userId) {
+  public Group isOwner(Long groupId, Long userId) {
     Group group = findByIdOrThrow(groupId);
     if(!group.getOwner().getId().equals(userId)) {
       throw new GroupException(GroupErrorCode.NOT_GROUP_OWNER);
     }
+    return group;
   }
 }

--- a/src/main/java/kr/ai/nemo/domain/group/validator/GroupValidator.java
+++ b/src/main/java/kr/ai/nemo/domain/group/validator/GroupValidator.java
@@ -36,4 +36,11 @@ public class GroupValidator {
       throw new GroupException(GroupErrorCode.GROUP_FULL);
     }
   }
+
+  public void isOwner(Long groupId, Long userId) {
+    Group group = findByIdOrThrow(groupId);
+    if(!group.getOwner().getId().equals(userId)) {
+      throw new GroupException(GroupErrorCode.NOT_GROUP_OWNER);
+    }
+  }
 }

--- a/src/main/java/kr/ai/nemo/domain/groupparticipants/controller/v1/GroupParticipantsController.java
+++ b/src/main/java/kr/ai/nemo/domain/groupparticipants/controller/v1/GroupParticipantsController.java
@@ -1,4 +1,4 @@
-package kr.ai.nemo.domain.groupparticipants.controller;
+package kr.ai.nemo.domain.groupparticipants.controller.v1;
 
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
@@ -29,8 +29,8 @@ import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
-@Tag(name = "모임원 API", description = "모임원 관련 API 입니다.")
-@RestController
+@Tag(name = "모임원 API (v1)", description = "모임원 관련 API 입니다.")
+@RestController("groupParticipantsControllerV1")
 @RequestMapping("/api/v1/groups")
 @RequiredArgsConstructor
 public class GroupParticipantsController {

--- a/src/main/java/kr/ai/nemo/domain/groupparticipants/controller/v2/GroupParticipantsController.java
+++ b/src/main/java/kr/ai/nemo/domain/groupparticipants/controller/v2/GroupParticipantsController.java
@@ -50,7 +50,7 @@ public class GroupParticipantsController {
       @PathVariable Long groupId,
       @AuthenticationPrincipal CustomUserDetails userDetails
   ) {
-    groupParticipantsCommandService.withdrawGroup(groupId, userDetails.getUserId());
+    // groupParticipantsCommandService.withdrawGroup(groupId, userDetails.getUserId());
     return ResponseEntity.noContent().build();
   }
 }

--- a/src/main/java/kr/ai/nemo/domain/groupparticipants/controller/v2/GroupParticipantsController.java
+++ b/src/main/java/kr/ai/nemo/domain/groupparticipants/controller/v2/GroupParticipantsController.java
@@ -40,4 +40,17 @@ public class GroupParticipantsController {
     groupParticipantsCommandService.kickOut(groupId, userId, userDetails);
     return ResponseEntity.noContent().build();
   }
+
+  @Operation(summary = "모임 탈퇴", description = "모임을 탈퇴합니다.")
+  @ApiResponse(responseCode = "204", description = "성공적으로 처리되었습니다.", content = @Content(schema = @Schema(implementation = BaseApiResponse.class)))
+  @SwaggerJwtErrorResponse
+  @TimeTrace
+  @DeleteMapping("/{groupId}/participants/me")
+  public ResponseEntity<BaseApiResponse<Object>> withdrawGroup(
+      @PathVariable Long groupId,
+      @AuthenticationPrincipal CustomUserDetails userDetails
+  ) {
+    groupParticipantsCommandService.withdrawGroup(groupId, userDetails.getUserId());
+    return ResponseEntity.noContent().build();
+  }
 }

--- a/src/main/java/kr/ai/nemo/domain/groupparticipants/controller/v2/GroupParticipantsController.java
+++ b/src/main/java/kr/ai/nemo/domain/groupparticipants/controller/v2/GroupParticipantsController.java
@@ -1,0 +1,43 @@
+package kr.ai.nemo.domain.groupparticipants.controller.v2;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import kr.ai.nemo.aop.logging.TimeTrace;
+import kr.ai.nemo.domain.auth.security.CustomUserDetails;
+import kr.ai.nemo.domain.groupparticipants.service.GroupParticipantsCommandService;
+import kr.ai.nemo.global.common.BaseApiResponse;
+import kr.ai.nemo.global.swagger.jwt.SwaggerJwtErrorResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@Tag(name = "모임원 API (v2)", description = "모임원 관련 API 입니다.")
+@RestController("groupParticipantsControllerV2")
+@RequestMapping("/api/v2/groups")
+@RequiredArgsConstructor
+public class GroupParticipantsController {
+
+  private final GroupParticipantsCommandService groupParticipantsCommandService;
+
+  @Operation(summary = "모임원 추방", description = "모임장이 모임원을 추방합니다.")
+  @ApiResponse(responseCode = "204", description = "성공적으로 처리되었습니다.", content = @Content(schema = @Schema(implementation = BaseApiResponse.class)))
+  @ApiResponse(responseCode = "403", description = "추방 권한이 없습니다.", content = @Content(schema = @Schema(implementation = BaseApiResponse.class)))
+  @SwaggerJwtErrorResponse
+  @TimeTrace
+  @DeleteMapping("/{groupId}/participants/{userId}")
+  public ResponseEntity<BaseApiResponse<Object>> deleteGroupParticipants(
+      @PathVariable Long groupId,
+      @PathVariable Long userId,
+      @AuthenticationPrincipal CustomUserDetails userDetails
+  ) {
+    groupParticipantsCommandService.kickOut(groupId, userId, userDetails);
+    return ResponseEntity.noContent().build();
+  }
+}

--- a/src/main/java/kr/ai/nemo/domain/groupparticipants/controller/v2/GroupParticipantsController.java
+++ b/src/main/java/kr/ai/nemo/domain/groupparticipants/controller/v2/GroupParticipantsController.java
@@ -50,7 +50,7 @@ public class GroupParticipantsController {
       @PathVariable Long groupId,
       @AuthenticationPrincipal CustomUserDetails userDetails
   ) {
-    // groupParticipantsCommandService.withdrawGroup(groupId, userDetails.getUserId());
+    groupParticipantsCommandService.withdrawGroup(groupId, userDetails.getUserId());
     return ResponseEntity.noContent().build();
   }
 }

--- a/src/main/java/kr/ai/nemo/domain/groupparticipants/domain/GroupParticipants.java
+++ b/src/main/java/kr/ai/nemo/domain/groupparticipants/domain/GroupParticipants.java
@@ -47,7 +47,6 @@ public class GroupParticipants {
   @Column(name = "role", nullable = false)
   private Role role;
 
-  @Setter
   @Enumerated(EnumType.STRING)
   @Column(name = "status", nullable = false)
   private Status status;
@@ -71,5 +70,10 @@ public class GroupParticipants {
   public void markAsJoined() {
     this.joinedAt = LocalDateTime.now();
     this.status = Status.JOINED;
+  }
+
+  public void setStatus(Status status) {
+    this.status = status;
+    this.deletedAt = LocalDateTime.now();
   }
 }

--- a/src/main/java/kr/ai/nemo/domain/groupparticipants/domain/enums/Role.java
+++ b/src/main/java/kr/ai/nemo/domain/groupparticipants/domain/enums/Role.java
@@ -8,7 +8,8 @@ import lombok.RequiredArgsConstructor;
 public enum Role {
   LEADER("모임장"),
   MEMBER("모임원"),
-  NON_MEMBER("일반 사용자");
+  NON_MEMBER("비모임원"),
+  GUEST("비로그인");
 
   private final String description;
 }

--- a/src/main/java/kr/ai/nemo/domain/groupparticipants/exception/GroupParticipantErrorCode.java
+++ b/src/main/java/kr/ai/nemo/domain/groupparticipants/exception/GroupParticipantErrorCode.java
@@ -14,7 +14,8 @@ public enum GroupParticipantErrorCode implements ErrorCode {
 
   // 409 Conflict
   ALREADY_KICKED_MEMBER("ALREADY_KICKED_MEMBER", "추방된 모임원입니다.", HttpStatus.CONFLICT),
-  ALREADY_WITHDRAWN_MEMBER("ALREADY_WITHDRAWN_MEMBER", "탈퇴한 모임원입니다.", HttpStatus.CONFLICT);
+  ALREADY_WITHDRAWN_MEMBER("ALREADY_WITHDRAWN_MEMBER", "탈퇴한 모임원입니다.", HttpStatus.CONFLICT),
+  LEADER_CANNOT_BE_REMOVED("LEADER_CANNOT_BE_REMOVED", "모임장은 탈퇴하거나 추방할 수 없습니다.", HttpStatus.CONFLICT),;
 
   private final String code;
   private final String message;

--- a/src/main/java/kr/ai/nemo/domain/groupparticipants/exception/GroupParticipantErrorCode.java
+++ b/src/main/java/kr/ai/nemo/domain/groupparticipants/exception/GroupParticipantErrorCode.java
@@ -13,7 +13,8 @@ public enum GroupParticipantErrorCode implements ErrorCode {
   NOT_GROUP_MEMBER("PARTICIPANT_NOT_FOUND", "모임원이 아닙니다.", HttpStatus.NOT_FOUND),
 
   // 409 Conflict
-  ALREADY_KICKED_MEMBER("ALREADY_KICKED_MEMBER", "이미 추방된 모임원입니다.", HttpStatus.CONFLICT);
+  ALREADY_KICKED_MEMBER("ALREADY_KICKED_MEMBER", "추방된 모임원입니다.", HttpStatus.CONFLICT),
+  ALREADY_WITHDRAWN_MEMBER("ALREADY_WITHDRAWN_MEMBER", "탈퇴한 모임원입니다.", HttpStatus.CONFLICT);
 
   private final String code;
   private final String message;

--- a/src/main/java/kr/ai/nemo/domain/groupparticipants/exception/GroupParticipantErrorCode.java
+++ b/src/main/java/kr/ai/nemo/domain/groupparticipants/exception/GroupParticipantErrorCode.java
@@ -10,7 +10,10 @@ import org.springframework.http.HttpStatus;
 public enum GroupParticipantErrorCode implements ErrorCode {
 
   // 404 NOT FOUND
-  NOT_GROUP_MEMBER("PARTICIPANT_NOT_FOUND", "모임원이 아닙니다.", HttpStatus.NOT_FOUND);
+  NOT_GROUP_MEMBER("PARTICIPANT_NOT_FOUND", "모임원이 아닙니다.", HttpStatus.NOT_FOUND),
+
+  // 409 Conflict
+  ALREADY_KICKED_MEMBER("ALREADY_KICKED_MEMBER", "이미 추방된 모임원입니다.", HttpStatus.CONFLICT);
 
   private final String code;
   private final String message;

--- a/src/main/java/kr/ai/nemo/domain/groupparticipants/repository/GroupParticipantsRepository.java
+++ b/src/main/java/kr/ai/nemo/domain/groupparticipants/repository/GroupParticipantsRepository.java
@@ -1,8 +1,11 @@
 package kr.ai.nemo.domain.groupparticipants.repository;
 
 import java.util.List;
+import java.util.Optional;
+import kr.ai.nemo.domain.group.domain.Group;
 import kr.ai.nemo.domain.groupparticipants.domain.GroupParticipants;
 import kr.ai.nemo.domain.groupparticipants.domain.enums.Status;
+import kr.ai.nemo.domain.user.domain.User;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
@@ -25,4 +28,10 @@ public interface GroupParticipantsRepository extends JpaRepository<GroupParticip
   List<GroupParticipants> findByUserIdAndStatus(Long userId, Status status);
 
   boolean existsByGroupIdAndUserIdAndStatus(Long groupId, Long userId, Status status);
+
+  List<GroupParticipants> user(User user);
+
+  List<GroupParticipants> group(Group group);
+
+  Optional<GroupParticipants> findByGroupIdAndUserId(Long groupId, Long userId);
 }

--- a/src/main/java/kr/ai/nemo/domain/groupparticipants/service/GroupParticipantsCommandService.java
+++ b/src/main/java/kr/ai/nemo/domain/groupparticipants/service/GroupParticipantsCommandService.java
@@ -45,4 +45,12 @@ public class GroupParticipantsCommandService {
     group.addCurrentUserCount();
     scheduleParticipantsService.addParticipantToUpcomingSchedules(group, user);
   }
+
+  @TimeTrace
+  @Transactional
+  public void kickOut(Long groupId, Long userId, CustomUserDetails userDetails) {
+    groupValidator.isOwner(groupId, userDetails.getUserId());
+    GroupParticipants participants = groupParticipantValidator.getParticipant(groupId, userId);
+    participants.setStatus(Status.KICKED);
+  }
 }

--- a/src/main/java/kr/ai/nemo/domain/groupparticipants/service/GroupParticipantsCommandService.java
+++ b/src/main/java/kr/ai/nemo/domain/groupparticipants/service/GroupParticipantsCommandService.java
@@ -49,8 +49,9 @@ public class GroupParticipantsCommandService {
   @TimeTrace
   @Transactional
   public void kickOut(Long groupId, Long userId, CustomUserDetails userDetails) {
-    groupValidator.isOwner(groupId, userDetails.getUserId());
+    Group group = groupValidator.isOwner(groupId, userDetails.getUserId());
     GroupParticipants participants = groupParticipantValidator.getParticipant(groupId, userId);
     participants.setStatus(Status.KICKED);
+    group.decreaseCurrentUserCount();
   }
 }

--- a/src/main/java/kr/ai/nemo/domain/groupparticipants/service/GroupParticipantsCommandService.java
+++ b/src/main/java/kr/ai/nemo/domain/groupparticipants/service/GroupParticipantsCommandService.java
@@ -51,6 +51,7 @@ public class GroupParticipantsCommandService {
   public void kickOut(Long groupId, Long userId, CustomUserDetails userDetails) {
     Group group = groupValidator.isOwner(groupId, userDetails.getUserId());
     GroupParticipants participants = groupParticipantValidator.getParticipant(groupId, userId);
+    groupParticipantValidator.checkOwner(participants);
     participants.setStatus(Status.KICKED);
     group.decreaseCurrentUserCount();
   }
@@ -60,6 +61,7 @@ public class GroupParticipantsCommandService {
   public void withdrawGroup(Long groupId, Long userId) {
     Group group = groupValidator.findByIdOrThrow(groupId);
     GroupParticipants participants = groupParticipantValidator.getParticipant(groupId, userId);
+    groupParticipantValidator.checkOwner(participants);
     participants.setStatus(Status.WITHDRAWN);
     group.decreaseCurrentUserCount();
   }

--- a/src/main/java/kr/ai/nemo/domain/groupparticipants/service/GroupParticipantsCommandService.java
+++ b/src/main/java/kr/ai/nemo/domain/groupparticipants/service/GroupParticipantsCommandService.java
@@ -54,4 +54,13 @@ public class GroupParticipantsCommandService {
     participants.setStatus(Status.KICKED);
     group.decreaseCurrentUserCount();
   }
+
+  @TimeTrace
+  @Transactional
+  public void withdrawGroup(Long groupId, Long userId) {
+    Group group = groupValidator.findByIdOrThrow(groupId);
+    GroupParticipants participants = groupParticipantValidator.getParticipant(groupId, userId);
+    participants.setStatus(Status.WITHDRAWN);
+    group.decreaseCurrentUserCount();
+  }
 }

--- a/src/main/java/kr/ai/nemo/domain/groupparticipants/validator/GroupParticipantValidator.java
+++ b/src/main/java/kr/ai/nemo/domain/groupparticipants/validator/GroupParticipantValidator.java
@@ -1,12 +1,14 @@
 package kr.ai.nemo.domain.groupparticipants.validator;
 
-import java.util.List;
 import kr.ai.nemo.domain.auth.security.CustomUserDetails;
 import kr.ai.nemo.domain.group.domain.Group;
 import kr.ai.nemo.domain.group.exception.GroupErrorCode;
 import kr.ai.nemo.domain.group.exception.GroupException;
 import kr.ai.nemo.domain.groupparticipants.domain.enums.Role;
+import kr.ai.nemo.domain.groupparticipants.domain.GroupParticipants;
 import kr.ai.nemo.domain.groupparticipants.domain.enums.Status;
+import kr.ai.nemo.domain.groupparticipants.exception.GroupParticipantErrorCode;
+import kr.ai.nemo.domain.groupparticipants.exception.GroupParticipantException;
 import kr.ai.nemo.domain.groupparticipants.repository.GroupParticipantsRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
@@ -16,6 +18,7 @@ import org.springframework.stereotype.Component;
 public class GroupParticipantValidator {
 
   private final GroupParticipantsRepository repository;
+  private final GroupParticipantsRepository groupParticipantsRepository;
 
   public void validateJoinedParticipant(Long groupId, Long userId) {
     boolean exists = repository.existsByGroupIdAndUserIdAndStatus(
@@ -45,5 +48,14 @@ public class GroupParticipantValidator {
     } else {
       return Role.NON_MEMBER;
     }
+  }
+
+  public GroupParticipants getParticipant(Long groupId, Long userId) {
+    GroupParticipants participants = groupParticipantsRepository.findByGroupIdAndUserId(groupId, userId)
+        .orElseThrow(() -> new GroupParticipantException(GroupParticipantErrorCode.NOT_GROUP_MEMBER));
+    if(participants.getStatus()==Status.KICKED){
+      throw new GroupParticipantException(GroupParticipantErrorCode.ALREADY_KICKED_MEMBER);
+    }
+    return participants;
   }
 }

--- a/src/main/java/kr/ai/nemo/domain/groupparticipants/validator/GroupParticipantValidator.java
+++ b/src/main/java/kr/ai/nemo/domain/groupparticipants/validator/GroupParticipantValidator.java
@@ -36,7 +36,7 @@ public class GroupParticipantValidator {
 
   public Role checkUserRole(CustomUserDetails userDetails, Group group) {
     if (userDetails == null) {
-      return Role.NON_MEMBER;
+      return Role.GUEST;
     }
 
     Long userId = userDetails.getUserId();

--- a/src/main/java/kr/ai/nemo/domain/groupparticipants/validator/GroupParticipantValidator.java
+++ b/src/main/java/kr/ai/nemo/domain/groupparticipants/validator/GroupParticipantValidator.java
@@ -60,4 +60,10 @@ public class GroupParticipantValidator {
     }
     return participants;
   }
+
+  public void checkOwner(GroupParticipants participants) {
+    if(participants.getRole()==Role.LEADER){
+      throw new GroupParticipantException(GroupParticipantErrorCode.LEADER_CANNOT_BE_REMOVED);
+    }
+  }
 }

--- a/src/main/java/kr/ai/nemo/domain/groupparticipants/validator/GroupParticipantValidator.java
+++ b/src/main/java/kr/ai/nemo/domain/groupparticipants/validator/GroupParticipantValidator.java
@@ -55,6 +55,8 @@ public class GroupParticipantValidator {
         .orElseThrow(() -> new GroupParticipantException(GroupParticipantErrorCode.NOT_GROUP_MEMBER));
     if(participants.getStatus()==Status.KICKED){
       throw new GroupParticipantException(GroupParticipantErrorCode.ALREADY_KICKED_MEMBER);
+    } else if(participants.getStatus()==Status.WITHDRAWN){
+      throw new GroupParticipantException(GroupParticipantErrorCode.ALREADY_WITHDRAWN_MEMBER);
     }
     return participants;
   }

--- a/src/test/java/kr/ai/nemo/domain/groupparticipants/controller/GroupParticipantsControllerTest.java
+++ b/src/test/java/kr/ai/nemo/domain/groupparticipants/controller/GroupParticipantsControllerTest.java
@@ -3,7 +3,9 @@ package kr.ai.nemo.domain.groupparticipants.controller;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.verify;
 import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
@@ -123,5 +125,22 @@ class GroupParticipantsControllerTest {
         .andExpect(jsonPath("$.data.groups[0].name").value("테스트 모임"))
         .andExpect(jsonPath("$.data.groups[1].groupId").value(2L))
         .andExpect(jsonPath("$.data.groups[1].name").value("테스트 모임"));
+  }
+
+  @Test
+  @DisplayName("[성공] 모임원 추방 테스트")
+  void kickGroupParticipant_Success() throws Exception {
+    // given
+    Long groupId = 1L;
+    Long userId = 1L;
+    CustomUserDetails userDetails = (CustomUserDetails) SecurityContextHolder.getContext().getAuthentication().getPrincipal();
+
+    // when
+    mockMvc.perform(delete("/api/v2/groups/{groupId}/participants/{userId}", groupId, userId)
+          .with(csrf()))
+        .andExpect(status().isNoContent());
+
+    // then
+    verify(groupParticipantsCommandService).kickOut(groupId, userId, userDetails);
   }
 }

--- a/src/test/java/kr/ai/nemo/domain/groupparticipants/controller/v1/GroupParticipantsControllerTest.java
+++ b/src/test/java/kr/ai/nemo/domain/groupparticipants/controller/v1/GroupParticipantsControllerTest.java
@@ -1,11 +1,9 @@
-package kr.ai.nemo.domain.groupparticipants.controller;
+package kr.ai.nemo.domain.groupparticipants.controller.v1;
 
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.doNothing;
-import static org.mockito.Mockito.verify;
 import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
@@ -125,22 +123,5 @@ class GroupParticipantsControllerTest {
         .andExpect(jsonPath("$.data.groups[0].name").value("테스트 모임"))
         .andExpect(jsonPath("$.data.groups[1].groupId").value(2L))
         .andExpect(jsonPath("$.data.groups[1].name").value("테스트 모임"));
-  }
-
-  @Test
-  @DisplayName("[성공] 모임원 추방 테스트")
-  void kickGroupParticipant_Success() throws Exception {
-    // given
-    Long groupId = 1L;
-    Long userId = 1L;
-    CustomUserDetails userDetails = (CustomUserDetails) SecurityContextHolder.getContext().getAuthentication().getPrincipal();
-
-    // when
-    mockMvc.perform(delete("/api/v2/groups/{groupId}/participants/{userId}", groupId, userId)
-          .with(csrf()))
-        .andExpect(status().isNoContent());
-
-    // then
-    verify(groupParticipantsCommandService).kickOut(groupId, userId, userDetails);
   }
 }

--- a/src/test/java/kr/ai/nemo/domain/groupparticipants/controller/v1/GroupParticipantsControllerTest.java
+++ b/src/test/java/kr/ai/nemo/domain/groupparticipants/controller/v1/GroupParticipantsControllerTest.java
@@ -35,7 +35,7 @@ import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
 
-@WebMvcTest(controllers = GroupParticipantsController.class)
+@WebMvcTest(controllers = kr.ai.nemo.domain.groupparticipants.controller.v1.GroupParticipantsController.class)
 @MockMember
 @Import(JwtProvider.class)
 @ActiveProfiles("test")

--- a/src/test/java/kr/ai/nemo/domain/groupparticipants/controller/v2/GroupParticipantsControllerTest.java
+++ b/src/test/java/kr/ai/nemo/domain/groupparticipants/controller/v2/GroupParticipantsControllerTest.java
@@ -53,4 +53,21 @@ class GroupParticipantsControllerTest {
     // then
     verify(groupParticipantsCommandService).kickOut(groupId, userId, userDetails);
   }
+
+  @Test
+  @DisplayName("[성공] 모임 탈퇴 테스트")
+  void withdrawFromGroup_Success() throws Exception {
+    // given
+    Long groupId = 1L;
+    Long userId = 1L;
+    CustomUserDetails userDetails = (CustomUserDetails) SecurityContextHolder.getContext().getAuthentication().getPrincipal();
+
+    // when
+    mockMvc.perform(delete("/api/v2/groups/{groupId}/participants/me", groupId, userId)
+        .with(csrf()))
+        .andExpect(status().isNoContent());
+
+    // then
+    verify(groupParticipantsCommandService).withdrawGroup(groupId, userDetails.getUserId());
+  }
 }

--- a/src/test/java/kr/ai/nemo/domain/groupparticipants/controller/v2/GroupParticipantsControllerTest.java
+++ b/src/test/java/kr/ai/nemo/domain/groupparticipants/controller/v2/GroupParticipantsControllerTest.java
@@ -21,7 +21,7 @@ import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
 
-@WebMvcTest(controllers = GroupParticipantsController.class)
+@WebMvcTest(controllers = kr.ai.nemo.domain.groupparticipants.controller.v2.GroupParticipantsController.class)
 @MockMember
 @Import(JwtProvider.class)
 @ActiveProfiles("test")

--- a/src/test/java/kr/ai/nemo/domain/groupparticipants/controller/v2/GroupParticipantsControllerTest.java
+++ b/src/test/java/kr/ai/nemo/domain/groupparticipants/controller/v2/GroupParticipantsControllerTest.java
@@ -1,0 +1,56 @@
+package kr.ai.nemo.domain.groupparticipants.controller.v2;
+
+import static org.mockito.Mockito.verify;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import kr.ai.nemo.domain.auth.security.CustomUserDetails;
+import kr.ai.nemo.domain.auth.security.JwtProvider;
+import kr.ai.nemo.domain.groupparticipants.controller.v1.GroupParticipantsController;
+import kr.ai.nemo.domain.groupparticipants.service.GroupParticipantsCommandService;
+import kr.ai.nemo.domain.user.repository.UserRepository;
+import kr.ai.nemo.global.testUtil.MockMember;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+@WebMvcTest(controllers = GroupParticipantsController.class)
+@MockMember
+@Import(JwtProvider.class)
+@ActiveProfiles("test")
+@DisplayName("GroupParticipantsController 테스트")
+class GroupParticipantsControllerTest {
+
+  @Autowired
+  private MockMvc mockMvc;
+
+  @MockitoBean
+  private GroupParticipantsCommandService groupParticipantsCommandService;
+
+  @MockitoBean
+  private UserRepository userRepository;
+
+  @Test
+  @DisplayName("[성공] 모임원 추방 테스트")
+  void kickGroupParticipant_Success() throws Exception {
+    // given
+    Long groupId = 1L;
+    Long userId = 1L;
+    CustomUserDetails userDetails = (CustomUserDetails) SecurityContextHolder.getContext().getAuthentication().getPrincipal();
+
+    // when
+    mockMvc.perform(delete("/api/v2/groups/{groupId}/participants/{userId}", groupId, userId)
+          .with(csrf()))
+        .andExpect(status().isNoContent());
+
+    // then
+    verify(groupParticipantsCommandService).kickOut(groupId, userId, userDetails);
+  }
+}

--- a/src/test/java/kr/ai/nemo/domain/groupparticipants/controller/v2/GroupParticipantsControllerTest.java
+++ b/src/test/java/kr/ai/nemo/domain/groupparticipants/controller/v2/GroupParticipantsControllerTest.java
@@ -7,7 +7,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 
 import kr.ai.nemo.domain.auth.security.CustomUserDetails;
 import kr.ai.nemo.domain.auth.security.JwtProvider;
-import kr.ai.nemo.domain.groupparticipants.controller.v1.GroupParticipantsController;
+import kr.ai.nemo.domain.auth.service.CustomUserDetailsService;
 import kr.ai.nemo.domain.groupparticipants.service.GroupParticipantsCommandService;
 import kr.ai.nemo.domain.user.repository.UserRepository;
 import kr.ai.nemo.global.testUtil.MockMember;
@@ -23,7 +23,7 @@ import org.springframework.test.web.servlet.MockMvc;
 
 @WebMvcTest(controllers = kr.ai.nemo.domain.groupparticipants.controller.v2.GroupParticipantsController.class)
 @MockMember
-@Import(JwtProvider.class)
+@Import({JwtProvider.class, CustomUserDetailsService.class})
 @ActiveProfiles("test")
 @DisplayName("GroupParticipantsController 테스트")
 class GroupParticipantsControllerTest {
@@ -43,11 +43,12 @@ class GroupParticipantsControllerTest {
     // given
     Long groupId = 1L;
     Long userId = 1L;
-    CustomUserDetails userDetails = (CustomUserDetails) SecurityContextHolder.getContext().getAuthentication().getPrincipal();
+    CustomUserDetails userDetails = (CustomUserDetails) SecurityContextHolder.getContext()
+        .getAuthentication().getPrincipal();
 
     // when
     mockMvc.perform(delete("/api/v2/groups/{groupId}/participants/{userId}", groupId, userId)
-          .with(csrf()))
+            .with(csrf()))
         .andExpect(status().isNoContent());
 
     // then
@@ -60,11 +61,12 @@ class GroupParticipantsControllerTest {
     // given
     Long groupId = 1L;
     Long userId = 1L;
-    CustomUserDetails userDetails = (CustomUserDetails) SecurityContextHolder.getContext().getAuthentication().getPrincipal();
+    CustomUserDetails userDetails = (CustomUserDetails) SecurityContextHolder.getContext()
+        .getAuthentication().getPrincipal();
 
     // when
     mockMvc.perform(delete("/api/v2/groups/{groupId}/participants/me", groupId, userId)
-        .with(csrf()))
+            .with(csrf()))
         .andExpect(status().isNoContent());
 
     // then

--- a/src/test/java/kr/ai/nemo/domain/groupparticipants/repository/GroupParticipantsRepositoryTest.java
+++ b/src/test/java/kr/ai/nemo/domain/groupparticipants/repository/GroupParticipantsRepositoryTest.java
@@ -2,6 +2,7 @@ package kr.ai.nemo.domain.groupparticipants.repository;
 
 import java.time.LocalDateTime;
 import java.util.List;
+import java.util.Optional;
 import kr.ai.nemo.domain.group.domain.Group;
 import kr.ai.nemo.domain.group.repository.GroupRepository;
 import kr.ai.nemo.domain.groupparticipants.domain.GroupParticipants;
@@ -25,82 +26,96 @@ import static org.assertj.core.api.Assertions.assertThat;
 @DisplayName("GroupParticipantsRepository 테스트")
 class GroupParticipantsRepositoryTest {
 
-    @Autowired
-    private GroupParticipantsRepository groupParticipantsRepository;
+  @Autowired
+  private GroupParticipantsRepository groupParticipantsRepository;
 
-    @Autowired
-    private UserRepository userRepository;
+  @Autowired
+  private UserRepository userRepository;
 
-    @Autowired
-    private GroupRepository groupRepository;
+  @Autowired
+  private GroupRepository groupRepository;
 
-    Group savedGroup;
-    User savedUser;
-    User savedUser1;
-    GroupParticipants participant;
-    @BeforeEach
-    void setUp() {
-        User user = UserFixture.createDefaultUser();
-        savedUser = userRepository.save(user);
+  Group savedGroup;
+  User savedUser;
+  User savedUser1;
+  GroupParticipants participant;
 
-        User user1 = UserFixture.createUser("testUser", "test11@example.com", "kakao", "12341234");
-        savedUser1 = userRepository.save(user1);
+  @BeforeEach
+  void setUp() {
+    User user = UserFixture.createDefaultUser();
+    savedUser = userRepository.save(user);
 
-        Group group = GroupFixture.createDefaultGroup(savedUser);
-        savedGroup = groupRepository.save(group);
+    User user1 = UserFixture.createUser("testUser", "test11@example.com", "kakao", "12341234");
+    savedUser1 = userRepository.save(user1);
 
-        participant = GroupParticipants.builder()
-            .user(savedUser1)
-            .group(savedGroup)
-            .role(Role.MEMBER)
-            .status(Status.JOINED)
-            .appliedAt(LocalDateTime.now())
-            .build();
+    Group group = GroupFixture.createDefaultGroup(savedUser);
+    savedGroup = groupRepository.save(group);
 
-        participant = groupParticipantsRepository.save(participant);
-    }
+    participant = GroupParticipants.builder()
+        .user(savedUser1)
+        .group(savedGroup)
+        .role(Role.MEMBER)
+        .status(Status.JOINED)
+        .appliedAt(LocalDateTime.now())
+        .build();
 
-    @Test
-    @DisplayName("[성공] 모임원 저장 테스트")
-    void save_Success() {
-        // when
-        GroupParticipants savedParticipant = groupParticipantsRepository.save(participant);
-        
-        // then
-        assertThat(savedParticipant.getUser()).isEqualTo(savedUser1);
-        assertThat(savedParticipant.getId()).isNotNull();
-        assertThat(savedParticipant.getRole()).isEqualTo(Role.MEMBER);
-        assertThat(savedParticipant.getStatus()).isEqualTo(Status.JOINED);
-    }
+    participant = groupParticipantsRepository.save(participant);
+  }
 
-    @Test
-    @DisplayName("[성공] 이미 모임에 신청했는지 검증 테스트")
-    void existsByGroupIdAndUserIdAndStatusIn_success() {
-        // when
-        boolean exists = groupParticipantsRepository.existsByGroupIdAndUserIdAndStatusIn(savedGroup.getId(), savedUser1.getId(), List.of(Status.JOINED));
+  @Test
+  @DisplayName("[성공] 모임원 저장 테스트")
+  void save_Success() {
+    // when
+    GroupParticipants savedParticipant = groupParticipantsRepository.save(participant);
 
-        // then
-        assertThat(exists).isTrue();
-    }
+    // then
+    assertThat(savedParticipant.getUser()).isEqualTo(savedUser1);
+    assertThat(savedParticipant.getId()).isNotNull();
+    assertThat(savedParticipant.getRole()).isEqualTo(Role.MEMBER);
+    assertThat(savedParticipant.getStatus()).isEqualTo(Status.JOINED);
+  }
 
-    @Test
-    @DisplayName("[성공] 모임원 list 조회 테스트")
-    void findByGroupIdAndStatusIn_success() {
-        // when
-        List<GroupParticipants> participants = groupParticipantsRepository.findByGroupIdAndStatus(savedGroup.getId(), Status.JOINED);
+  @Test
+  @DisplayName("[성공] 이미 모임에 신청했는지 검증 테스트")
+  void existsByGroupIdAndUserIdAndStatusIn_success() {
+    // when
+    boolean exists = groupParticipantsRepository.existsByGroupIdAndUserIdAndStatusIn(
+        savedGroup.getId(), savedUser1.getId(), List.of(Status.JOINED));
 
-        // then
-        assertThat(participants).hasSize(1);
-        assertThat(participants.getFirst().getUser()).isEqualTo(savedUser1);
-    }
+    // then
+    assertThat(exists).isTrue();
+  }
 
-    @Test
-    @DisplayName("[성공] 모임원인지 검증 테스트")
-    void existsByGroupIdAndUserIdAndStatus_success() {
-        // when
-        boolean exists = groupParticipantsRepository.existsByGroupIdAndUserIdAndStatus(savedGroup.getId(), savedUser1.getId(), Status.JOINED);
+  @Test
+  @DisplayName("[성공] 모임원 list 조회 테스트")
+  void findByGroupIdAndStatusIn_success() {
+    // when
+    List<GroupParticipants> participants = groupParticipantsRepository.findByGroupIdAndStatus(
+        savedGroup.getId(), Status.JOINED);
 
-        // then
-        assertThat(exists).isTrue();
-    }
+    // then
+    assertThat(participants).hasSize(1);
+    assertThat(participants.getFirst().getUser()).isEqualTo(savedUser1);
+  }
+
+  @Test
+  @DisplayName("[성공] 모임원인지 검증 테스트")
+  void existsByGroupIdAndUserIdAndStatus_success() {
+    // when
+    boolean exists = groupParticipantsRepository.existsByGroupIdAndUserIdAndStatus(
+        savedGroup.getId(), savedUser1.getId(), Status.JOINED);
+
+    // then
+    assertThat(exists).isTrue();
+  }
+
+  @Test
+  @DisplayName("[성공] 모임원 조회")
+  void findByGroupIdAndUserId_success() {
+    // when
+    Optional<GroupParticipants> findParticipant = groupParticipantsRepository.findByGroupIdAndUserId(savedGroup.getId(), savedUser1.getId());
+
+    // then
+    assertThat(findParticipant).isPresent();
+  }
 }

--- a/src/test/java/kr/ai/nemo/domain/groupparticipants/service/GroupParticipantsCommandServiceTest.java
+++ b/src/test/java/kr/ai/nemo/domain/groupparticipants/service/GroupParticipantsCommandServiceTest.java
@@ -1,11 +1,16 @@
 package kr.ai.nemo.domain.groupparticipants.service;
 
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.BDDMockito.given;
 import static org.mockito.BDDMockito.willDoNothing;
+import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import java.time.LocalDateTime;
 import kr.ai.nemo.domain.auth.security.CustomUserDetails;
 import kr.ai.nemo.domain.group.domain.Group;
 import kr.ai.nemo.domain.group.validator.GroupValidator;
@@ -18,6 +23,7 @@ import kr.ai.nemo.domain.group.repository.GroupRepository;
 import kr.ai.nemo.domain.scheduleparticipants.service.ScheduleParticipantsService;
 import kr.ai.nemo.domain.user.domain.User;
 import kr.ai.nemo.domain.user.repository.UserRepository;
+import kr.ai.nemo.global.fixture.group.GroupFixture;
 import kr.ai.nemo.global.fixture.user.UserFixture;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -81,5 +87,39 @@ class GroupParticipantsCommandServiceTest {
     verify(groupParticipantsRepository).save(any(GroupParticipants.class));
     verify(mockGroup).addCurrentUserCount();
     verify(scheduleParticipantsService).addParticipantToUpcomingSchedules(mockGroup, mockUser);
+  }
+
+  @Test
+  @DisplayName("[성공] 모임원 추방 테스트")
+  void kickOut_Success() {
+    // given
+    Long groupId = 1L;
+    Long userId = 1L;
+
+    User user = mock(User.class);
+    Group group = mock(Group.class);
+
+    CustomUserDetails userDetails = new CustomUserDetails(user);
+
+    GroupParticipants mockParticipant = new GroupParticipants(
+        1L,
+        user,
+        group,
+        Role.MEMBER,
+        Status.JOINED,
+        LocalDateTime.now(),
+        LocalDateTime.now(),
+        null
+    );
+
+    doNothing().when(groupValidator).isOwner(groupId, userDetails.getUserId());
+    given(groupParticipantValidator.getParticipant(anyLong(), anyLong()))
+        .willReturn(mockParticipant);
+
+    // when
+    groupParticipantsCommandService.kickOut(groupId, userId, userDetails);
+
+    // then
+    assertThat(mockParticipant.getStatus()).isEqualTo(Status.KICKED);
   }
 }

--- a/src/test/java/kr/ai/nemo/domain/groupparticipants/service/GroupParticipantsCommandServiceTest.java
+++ b/src/test/java/kr/ai/nemo/domain/groupparticipants/service/GroupParticipantsCommandServiceTest.java
@@ -114,6 +114,8 @@ class GroupParticipantsCommandServiceTest {
         null
     );
 
+    willDoNothing().given(groupParticipantValidator).checkOwner(mockParticipant);
+
     given(groupValidator.isOwner(groupId, userDetails.getUserId()))
         .willReturn(group);
     given(groupParticipantValidator.getParticipant(anyLong(), anyLong()))
@@ -148,6 +150,8 @@ class GroupParticipantsCommandServiceTest {
         LocalDateTime.now(),
         null
     );
+
+    willDoNothing().given(groupParticipantValidator).checkOwner(mockParticipant);
 
     given(groupValidator.findByIdOrThrow(groupId))
         .willReturn(group);

--- a/src/test/java/kr/ai/nemo/domain/groupparticipants/service/GroupParticipantsCommandServiceTest.java
+++ b/src/test/java/kr/ai/nemo/domain/groupparticipants/service/GroupParticipantsCommandServiceTest.java
@@ -97,7 +97,9 @@ class GroupParticipantsCommandServiceTest {
     Long userId = 1L;
 
     User user = mock(User.class);
-    Group group = mock(Group.class);
+    Group group = GroupFixture.createDefaultGroup(user);
+    groupRepository.saveAndFlush(group);
+    group.setCurrentUserCount(5);
 
     CustomUserDetails userDetails = new CustomUserDetails(user);
 
@@ -112,7 +114,8 @@ class GroupParticipantsCommandServiceTest {
         null
     );
 
-    doNothing().when(groupValidator).isOwner(groupId, userDetails.getUserId());
+    given(groupValidator.isOwner(groupId, userDetails.getUserId()))
+        .willReturn(group);
     given(groupParticipantValidator.getParticipant(anyLong(), anyLong()))
         .willReturn(mockParticipant);
 
@@ -121,5 +124,6 @@ class GroupParticipantsCommandServiceTest {
 
     // then
     assertThat(mockParticipant.getStatus()).isEqualTo(Status.KICKED);
+    assertThat(group.getCurrentUserCount()).isEqualTo(4);
   }
 }

--- a/src/test/java/kr/ai/nemo/domain/groupparticipants/service/GroupParticipantsCommandServiceTest.java
+++ b/src/test/java/kr/ai/nemo/domain/groupparticipants/service/GroupParticipantsCommandServiceTest.java
@@ -126,4 +126,40 @@ class GroupParticipantsCommandServiceTest {
     assertThat(mockParticipant.getStatus()).isEqualTo(Status.KICKED);
     assertThat(group.getCurrentUserCount()).isEqualTo(4);
   }
+
+  @Test
+  @DisplayName("[성공] 모임 탈퇴 테스트")
+  void withdrawGroup_Success() {
+    // given
+    Long groupId = 1L;
+    User user = mock(User.class);
+    CustomUserDetails userDetails = new CustomUserDetails(user);
+    Group group = GroupFixture.createDefaultGroup(user);
+    groupRepository.saveAndFlush(group);
+    group.setCurrentUserCount(5);
+
+    GroupParticipants mockParticipant = new GroupParticipants(
+        1L,
+        user,
+        group,
+        Role.MEMBER,
+        Status.JOINED,
+        LocalDateTime.now(),
+        LocalDateTime.now(),
+        null
+    );
+
+    given(groupValidator.findByIdOrThrow(groupId))
+        .willReturn(group);
+    given(groupParticipantValidator.getParticipant(anyLong(), anyLong()))
+        .willReturn(mockParticipant);
+
+    // when
+    groupParticipantsCommandService.withdrawGroup(groupId, userDetails.getUserId());
+
+    // then
+    assertThat(group.getCurrentUserCount()).isEqualTo(4);
+    assertThat(mockParticipant.getStatus()).isEqualTo(Status.WITHDRAWN);
+    assertThat(mockParticipant.getDeletedAt()).isNotNull();
+  }
 }


### PR DESCRIPTION
## What
> 무엇을 작업했는지 간결하게 적습니다.

→ 모임원 추방 API를 구현하였습니다.
→ 모임 탈퇴 API를 구현하였습니다.

## Why
> 왜 이 작업을 했는지 설명합니다.

→ 모임을 더 잘 관리하고, 자유롭게 탈퇴할 수 있도록 하기 위함입니다.

## Changes
> 주요 변경사항을 적습니다.

→ 모임원 도메인 내 controller와 service 로직을 추가하였습니다.
→ 단위 테스트 코드 작성하였습니다.

## Related Issue
> 관련 이슈 번호를 연결합니다.

→ #131 