### PR TITLE
모임 대표 사진 수정, 모임 해체 API

### DIFF
--- a/src/main/java/kr/ai/nemo/domain/group/controller/v1/GroupController.java
+++ b/src/main/java/kr/ai/nemo/domain/group/controller/v1/GroupController.java
@@ -1,4 +1,4 @@
-package kr.ai.nemo.domain.group.controller;
+package kr.ai.nemo.domain.group.controller.v1;
 
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.media.Content;
@@ -45,7 +45,7 @@ import org.springframework.web.servlet.support.ServletUriComponentsBuilder;
 import java.net.URI;
 
 @Tag(name = "모임 API", description = "모임 관련 API 입니다.")
-@RestController
+@RestController("groupControllerV1")
 @RequestMapping("/api/v1/groups")
 @RequiredArgsConstructor
 public class GroupController {

--- a/src/main/java/kr/ai/nemo/domain/group/controller/v2/GroupController.java
+++ b/src/main/java/kr/ai/nemo/domain/group/controller/v2/GroupController.java
@@ -1,0 +1,39 @@
+package kr.ai.nemo.domain.group.controller.v2;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import kr.ai.nemo.aop.logging.TimeTrace;
+import kr.ai.nemo.domain.auth.security.CustomUserDetails;
+import kr.ai.nemo.domain.group.service.GroupCommandService;
+import kr.ai.nemo.global.common.BaseApiResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@Tag(name = "모임 API", description = "모임 관련 API 입니다.")
+@RestController("groupControllerV2")
+@RequestMapping("/api/v2/groups")
+@RequiredArgsConstructor
+public class GroupController {
+  private final GroupCommandService groupCommandService;
+
+  @Operation(summary = "모임 해체", description = "모임을 해체합니다.")
+  @ApiResponse(responseCode = "204", description = "성공적으로 처리되었습니다.", content = @Content(schema = @Schema(implementation = BaseApiResponse.class)))
+  @TimeTrace
+  @DeleteMapping("/{groupId}")
+  public ResponseEntity<BaseApiResponse<Object>> deleteGroup(
+      @PathVariable Long groupId,
+      @AuthenticationPrincipal CustomUserDetails userDetails
+  ) {
+    groupCommandService.deleteGroup(userDetails.getUserId(), groupId);
+    return ResponseEntity.noContent().build();
+  }
+
+}

--- a/src/main/java/kr/ai/nemo/domain/group/controller/v2/GroupController.java
+++ b/src/main/java/kr/ai/nemo/domain/group/controller/v2/GroupController.java
@@ -7,13 +7,16 @@ import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import kr.ai.nemo.aop.logging.TimeTrace;
 import kr.ai.nemo.domain.auth.security.CustomUserDetails;
+import kr.ai.nemo.domain.group.dto.request.UpdateGroupImageRequest;
 import kr.ai.nemo.domain.group.service.GroupCommandService;
 import kr.ai.nemo.global.common.BaseApiResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -32,8 +35,20 @@ public class GroupController {
       @PathVariable Long groupId,
       @AuthenticationPrincipal CustomUserDetails userDetails
   ) {
-    groupCommandService.deleteGroup(userDetails.getUserId(), groupId);
+    groupCommandService.deleteGroup(groupId, userDetails.getUserId());
     return ResponseEntity.noContent().build();
   }
 
+  @Operation(summary = "모임 대표 사진 수정", description = "모임을 해체합니다.")
+  @ApiResponse(responseCode = "200", description = "성공적으로 처리되었습니다.", content = @Content(schema = @Schema(implementation = BaseApiResponse.class)))
+  @TimeTrace
+  @PatchMapping("/{groupId}/image")
+  public ResponseEntity<BaseApiResponse<Object>> updateGroupImage(
+      @PathVariable Long groupId,
+      @RequestBody UpdateGroupImageRequest request,
+      @AuthenticationPrincipal CustomUserDetails userDetails
+  ) {
+    groupCommandService.updateGroupImage(groupId, userDetails.getUserId(), request);
+    return ResponseEntity.noContent().build();
+  }
 }

--- a/src/main/java/kr/ai/nemo/domain/group/domain/Group.java
+++ b/src/main/java/kr/ai/nemo/domain/group/domain/Group.java
@@ -119,4 +119,10 @@ public class Group {
   public void addCompleteSchedule() {
     this.completedScheduleTotal++;
   }
+
+  public void deleteGroup() {
+    this.status = GroupStatus.DISBANDED;
+    this.groupTags.clear();
+    this.deletedAt = LocalDateTime.now();
+  }
 }

--- a/src/main/java/kr/ai/nemo/domain/group/dto/request/UpdateGroupImageRequest.java
+++ b/src/main/java/kr/ai/nemo/domain/group/dto/request/UpdateGroupImageRequest.java
@@ -1,0 +1,5 @@
+package kr.ai.nemo.domain.group.dto.request;
+
+public record UpdateGroupImageRequest (
+  String imageUrl
+) {}

--- a/src/main/java/kr/ai/nemo/domain/group/exception/GroupErrorCode.java
+++ b/src/main/java/kr/ai/nemo/domain/group/exception/GroupErrorCode.java
@@ -16,6 +16,7 @@ public enum GroupErrorCode implements ErrorCode {
   // 403 Forbidden
   GROUP_KICK_FORBIDDEN("GROUP_KICK_FORBIDDEN", "추방 권한이 없습니다.", HttpStatus.FORBIDDEN),
   GROUP_DELETE_FORBIDDEN("GROUP_DELETE_FORBIDDEN", "해체 권한이 없습니다.", HttpStatus.FORBIDDEN),
+  GROUP_UPDATE_FORBIDDEN("GROUP_UPDATE_FORBIDDEN", "변경 권한이 없습니다.", HttpStatus.FORBIDDEN),
 
   // 404 NOT FOUND
   GROUP_NOT_FOUND("GROUP_NOT_FOUND", "모임을 찾을 수 없습니다.", HttpStatus.NOT_FOUND),

--- a/src/main/java/kr/ai/nemo/domain/group/exception/GroupErrorCode.java
+++ b/src/main/java/kr/ai/nemo/domain/group/exception/GroupErrorCode.java
@@ -14,7 +14,8 @@ public enum GroupErrorCode implements ErrorCode {
   INVALID_CATEGORY("INVALID_CATEGOTY","올바르지 않은 모임 카테고리입니다.", HttpStatus.BAD_REQUEST ),
 
   // 403 Forbidden
-  NOT_GROUP_OWNER("GROUP_KICK_FORBIDDEN", "추방 권한이 없습니다.", HttpStatus.FORBIDDEN),
+  GROUP_KICK_FORBIDDEN("GROUP_KICK_FORBIDDEN", "추방 권한이 없습니다.", HttpStatus.FORBIDDEN),
+  GROUP_DELETE_FORBIDDEN("GROUP_DELETE_FORBIDDEN", "해체 권한이 없습니다.", HttpStatus.FORBIDDEN),
 
   // 404 NOT FOUND
   GROUP_NOT_FOUND("GROUP_NOT_FOUND", "모임을 찾을 수 없습니다.", HttpStatus.NOT_FOUND),

--- a/src/main/java/kr/ai/nemo/domain/group/service/GroupCommandService.java
+++ b/src/main/java/kr/ai/nemo/domain/group/service/GroupCommandService.java
@@ -61,4 +61,11 @@ public class GroupCommandService {
 
     return GroupCreateResponse.from(savedGroup, tags);
   }
+
+  @TimeTrace
+  @Transactional
+  public void deleteGroup(Long userId, Long groupId) {
+    Group group = groupValidator.isOwnerForGroupDelete(groupId, userId);
+    group.deleteGroup();
+  }
 }

--- a/src/main/java/kr/ai/nemo/domain/group/service/GroupCommandService.java
+++ b/src/main/java/kr/ai/nemo/domain/group/service/GroupCommandService.java
@@ -7,6 +7,7 @@ import kr.ai.nemo.domain.auth.security.CustomUserDetails;
 import kr.ai.nemo.domain.group.domain.Group;
 import kr.ai.nemo.domain.group.domain.enums.GroupStatus;
 import kr.ai.nemo.domain.group.dto.request.GroupCreateRequest;
+import kr.ai.nemo.domain.group.dto.request.UpdateGroupImageRequest;
 import kr.ai.nemo.domain.group.dto.response.GroupCreateResponse;
 import kr.ai.nemo.domain.group.validator.GroupValidator;
 import kr.ai.nemo.domain.groupparticipants.domain.enums.Role;
@@ -64,8 +65,15 @@ public class GroupCommandService {
 
   @TimeTrace
   @Transactional
-  public void deleteGroup(Long userId, Long groupId) {
+  public void deleteGroup(Long groupId, Long userId) {
     Group group = groupValidator.isOwnerForGroupDelete(groupId, userId);
     group.deleteGroup();
+  }
+
+  @TimeTrace
+  @Transactional
+  public void updateGroupImage(Long groupId, Long userId, UpdateGroupImageRequest request) {
+    Group group = groupValidator.isOwnerForGroupUpdate(groupId, userId);
+    group.setImageUrl(imageService.updateImage(group.getImageUrl(), request.imageUrl()));
   }
 }

--- a/src/main/java/kr/ai/nemo/domain/group/validator/GroupValidator.java
+++ b/src/main/java/kr/ai/nemo/domain/group/validator/GroupValidator.java
@@ -40,7 +40,15 @@ public class GroupValidator {
   public Group isOwner(Long groupId, Long userId) {
     Group group = findByIdOrThrow(groupId);
     if(!group.getOwner().getId().equals(userId)) {
-      throw new GroupException(GroupErrorCode.NOT_GROUP_OWNER);
+      throw new GroupException(GroupErrorCode.GROUP_KICK_FORBIDDEN);
+    }
+    return group;
+  }
+
+  public Group isOwnerForGroupDelete(Long groupId, Long userId) {
+    Group group = findByIdOrThrow(groupId);
+    if(!group.getOwner().getId().equals(userId)) {
+      throw new GroupException(GroupErrorCode.GROUP_DELETE_FORBIDDEN);
     }
     return group;
   }

--- a/src/main/java/kr/ai/nemo/domain/group/validator/GroupValidator.java
+++ b/src/main/java/kr/ai/nemo/domain/group/validator/GroupValidator.java
@@ -52,4 +52,12 @@ public class GroupValidator {
     }
     return group;
   }
+
+  public Group isOwnerForGroupUpdate(Long groupId, Long userId) {
+    Group group = findByIdOrThrow(groupId);
+    if(!group.getOwner().getId().equals(userId)) {
+      throw new GroupException(GroupErrorCode.GROUP_UPDATE_FORBIDDEN);
+    }
+    return group;
+  }
 }

--- a/src/test/java/kr/ai/nemo/domain/group/controller/v1/GroupControllerTest.java
+++ b/src/test/java/kr/ai/nemo/domain/group/controller/v1/GroupControllerTest.java
@@ -1,4 +1,4 @@
-package kr.ai.nemo.domain.group.controller;
+package kr.ai.nemo.domain.group.controller.v1;
 
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyLong;
@@ -29,7 +29,6 @@ import kr.ai.nemo.domain.groupparticipants.domain.enums.Role;
 import kr.ai.nemo.domain.schedule.domain.enums.ScheduleStatus;
 import kr.ai.nemo.domain.schedule.dto.response.ScheduleListResponse;
 import kr.ai.nemo.domain.schedule.service.ScheduleQueryService;
-import kr.ai.nemo.domain.user.repository.UserRepository;
 import kr.ai.nemo.global.testUtil.MockMember;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -44,11 +43,11 @@ import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
 
-@WebMvcTest(controllers = GroupController.class)
+@WebMvcTest(controllers = kr.ai.nemo.domain.group.controller.v1.GroupController.class)
 @MockMember
 @Import(JwtProvider.class)
 @ActiveProfiles("test")
-@DisplayName("GroupController 테스트")
+@DisplayName("GroupControllerV1 테스트")
 class GroupControllerTest {
 
   @Autowired

--- a/src/test/java/kr/ai/nemo/domain/group/controller/v2/GroupControllerTest.java
+++ b/src/test/java/kr/ai/nemo/domain/group/controller/v2/GroupControllerTest.java
@@ -4,10 +4,13 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.ArgumentMatchers.any;
 import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import kr.ai.nemo.domain.auth.security.JwtProvider;
 import kr.ai.nemo.domain.auth.service.CustomUserDetailsService;
+import kr.ai.nemo.domain.group.dto.request.UpdateGroupImageRequest;
 import kr.ai.nemo.domain.group.service.GroupCommandService;
 import kr.ai.nemo.global.testUtil.MockMember;
 import org.junit.jupiter.api.DisplayName;
@@ -15,6 +18,7 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.context.annotation.Import;
+import org.springframework.http.MediaType;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
@@ -34,6 +38,8 @@ class GroupControllerTest {
 
   @MockitoBean
   private CustomUserDetailsService customUserDetailsService;
+  @Autowired
+  private ObjectMapper objectMapper;
 
 
   @Test
@@ -49,5 +55,27 @@ class GroupControllerTest {
 
     // then
     verify(groupCommandService).deleteGroup(any(), any()); // Service 호출 검증
+  }
+
+  @Test
+  @DisplayName("[성공] 모임 대표 사진 수정 테스트")
+  void updateGroupImage_Success() throws Exception {
+    // given
+    Long groupId = 1L;
+    Long userId = 1L;
+
+    UpdateGroupImageRequest request = new UpdateGroupImageRequest(
+        "newGroupImage"
+    );
+
+    // when
+    mockMvc.perform(patch("/api/v2/groups/{groupId}/image", groupId)
+            .with(csrf())
+            .contentType(MediaType.APPLICATION_JSON)
+            .content(objectMapper.writeValueAsString(request)))
+        .andExpect(status().isNoContent());
+
+    // then
+    verify(groupCommandService).updateGroupImage(groupId, userId, request); // Service 호출 검증
   }
 }

--- a/src/test/java/kr/ai/nemo/domain/group/controller/v2/GroupControllerTest.java
+++ b/src/test/java/kr/ai/nemo/domain/group/controller/v2/GroupControllerTest.java
@@ -1,0 +1,53 @@
+package kr.ai.nemo.domain.group.controller.v2;
+
+import static org.mockito.Mockito.verify;
+import static org.mockito.ArgumentMatchers.any;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import kr.ai.nemo.domain.auth.security.JwtProvider;
+import kr.ai.nemo.domain.auth.service.CustomUserDetailsService;
+import kr.ai.nemo.domain.group.service.GroupCommandService;
+import kr.ai.nemo.global.testUtil.MockMember;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+@WebMvcTest(controllers = kr.ai.nemo.domain.group.controller.v2.GroupController.class)
+@MockMember
+@Import({JwtProvider.class})
+@ActiveProfiles("test")
+@DisplayName("GroupControllerV2 테스트")
+class GroupControllerTest {
+
+  @Autowired
+  private MockMvc mockMvc;
+
+  @MockitoBean
+  private GroupCommandService groupCommandService;
+
+  @MockitoBean
+  private CustomUserDetailsService customUserDetailsService;
+
+
+  @Test
+  @DisplayName("[성공] 모임 해체 테스트")
+  void deleteGroup_Success() throws Exception {
+    // given
+    Long groupId = 1L;
+
+    // when
+    mockMvc.perform(delete("/api/v2/groups/{groupId}", groupId)
+            .with(csrf()))
+        .andExpect(status().isNoContent());
+
+    // then
+    verify(groupCommandService).deleteGroup(any(), any()); // Service 호출 검증
+  }
+}

--- a/src/test/java/kr/ai/nemo/domain/group/service/GroupCommandServiceTest.java
+++ b/src/test/java/kr/ai/nemo/domain/group/service/GroupCommandServiceTest.java
@@ -8,12 +8,14 @@ import static org.mockito.BDDMockito.given;
 import static org.mockito.BDDMockito.then;
 import static org.mockito.BDDMockito.willDoNothing;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
 
 import java.util.List;
 import kr.ai.nemo.domain.auth.security.CustomUserDetails;
 import kr.ai.nemo.domain.group.domain.Group;
 import kr.ai.nemo.domain.group.domain.enums.GroupStatus;
 import kr.ai.nemo.domain.group.dto.request.GroupCreateRequest;
+import kr.ai.nemo.domain.group.dto.request.UpdateGroupImageRequest;
 import kr.ai.nemo.domain.group.dto.response.GroupCreateResponse;
 import kr.ai.nemo.domain.group.repository.GroupRepository;
 import kr.ai.nemo.domain.group.validator.GroupValidator;
@@ -128,11 +130,35 @@ class GroupCommandServiceTest {
     given(groupValidator.isOwnerForGroupDelete(groupId, userId)).willReturn(group);
 
     // when
-    groupCommandService.deleteGroup(userId, groupId);
+    groupCommandService.deleteGroup(groupId, userId);
 
     // then
     assertThat(group.getStatus()).isEqualTo(GroupStatus.DISBANDED);
     assertThat(group.getDeletedAt()).isNotNull();
     assertThat(group.getGroupTags()).isEmpty();
+  }
+
+  @Test
+  @DisplayName("[성공] 모임 대표 사진 수정 테스트")
+  void updateGroupImage_Success() {
+    // given
+    Long userId = 1L;
+    Long groupId = 1L;
+    User user = mock(User.class);
+
+    Group group = GroupFixture.createDefaultGroup(user);
+    String oldImage = group.getImageUrl();
+
+    UpdateGroupImageRequest request = new UpdateGroupImageRequest("newGroupImage");
+
+    given(groupValidator.isOwnerForGroupUpdate(groupId, userId)).willReturn(group);
+    given(imageService.updateImage(group.getImageUrl(), request.imageUrl())).willReturn("newGroupImage.jpg");
+
+    // when
+    groupCommandService.updateGroupImage(groupId, userId, request);
+
+    // then
+    assertThat(group.getImageUrl()).isEqualTo("newGroupImage.jpg");
+    verify(imageService).updateImage(oldImage, request.imageUrl());
   }
 }

--- a/src/test/java/kr/ai/nemo/domain/group/service/GroupCommandServiceTest.java
+++ b/src/test/java/kr/ai/nemo/domain/group/service/GroupCommandServiceTest.java
@@ -1,16 +1,18 @@
 package kr.ai.nemo.domain.group.service;
 
-import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyList;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.BDDMockito.then;
 import static org.mockito.BDDMockito.willDoNothing;
+import static org.mockito.Mockito.mock;
 
 import java.util.List;
 import kr.ai.nemo.domain.auth.security.CustomUserDetails;
 import kr.ai.nemo.domain.group.domain.Group;
+import kr.ai.nemo.domain.group.domain.enums.GroupStatus;
 import kr.ai.nemo.domain.group.dto.request.GroupCreateRequest;
 import kr.ai.nemo.domain.group.dto.response.GroupCreateResponse;
 import kr.ai.nemo.domain.group.repository.GroupRepository;
@@ -19,6 +21,7 @@ import kr.ai.nemo.domain.groupparticipants.domain.enums.Role;
 import kr.ai.nemo.domain.groupparticipants.domain.enums.Status;
 import kr.ai.nemo.domain.groupparticipants.service.GroupParticipantsCommandService;
 import kr.ai.nemo.domain.user.domain.User;
+import kr.ai.nemo.global.fixture.group.GroupFixture;
 import kr.ai.nemo.global.fixture.user.UserFixture;
 import kr.ai.nemo.global.testUtil.TestReflectionUtils;
 import kr.ai.nemo.infra.ImageService;
@@ -110,5 +113,26 @@ class GroupCommandServiceTest {
     then(groupParticipantsCommandService).should()
         .applyToGroup(anyLong(), any(CustomUserDetails.class), any(Role.class), any(Status.class));
     then(groupTagService).should().getTagNamesByGroupId(any(Long.class));
+  }
+
+  @Test
+  @DisplayName("[성공] 모임 해체 테스트")
+  void deleteGroup_Success() {
+    // given
+    Long userId = 1L;
+    Long groupId = 1L;
+
+    User user = mock(User.class);
+    Group group = GroupFixture.createDefaultGroup(user);
+
+    given(groupValidator.isOwnerForGroupDelete(groupId, userId)).willReturn(group);
+
+    // when
+    groupCommandService.deleteGroup(userId, groupId);
+
+    // then
+    assertThat(group.getStatus()).isEqualTo(GroupStatus.DISBANDED);
+    assertThat(group.getDeletedAt()).isNotNull();
+    assertThat(group.getGroupTags()).isEmpty();
   }
 }


### PR DESCRIPTION
## What
> 무엇을 작업했는지 간결하게 적습니다.

→ 모임 대표 사진 수정 API를 개발합니다.
→ 모임 해체 API를 개발합니다.

## Why
> 왜 이 작업을 했는지 설명합니다.

→ 모임을 나타내는 대표 사진을 수정할 수 있습니다.
→ 모임을 해체할 수 있도록 합니다.

## Changes
> 주요 변경사항을 적습니다.

→ S3에 이미지를 업데이트 하면, 기존 이미지는 삭제되도록 합니다.
→ 모임을 해체하면 상태값을 변경합니다.

## Related Issue
> 관련 이슈 번호를 연결합니다.

→ #130 
