### PR TITLE
fix: Security Context에서 userDetails를 뽑도록 변경 (#139)

### DIFF
--- a/src/main/java/kr/ai/nemo/aop/role/aspect/GroupParticipantAspect.java
+++ b/src/main/java/kr/ai/nemo/aop/role/aspect/GroupParticipantAspect.java
@@ -1,5 +1,6 @@
 package kr.ai.nemo.aop.role.aspect;
 
+import kr.ai.nemo.domain.auth.security.CustomUserDetails;
 import kr.ai.nemo.domain.group.exception.GroupErrorCode;
 import kr.ai.nemo.domain.group.exception.GroupException;
 import kr.ai.nemo.domain.groupparticipants.exception.GroupParticipantErrorCode;
@@ -22,7 +23,8 @@ public class GroupParticipantAspect {
 
   @Before("@annotation(kr.ai.nemo.aop.role.annotation.RequireGroupParticipant)")
   public void checkGroupMembership(JoinPoint joinPoint) {
-    Long userId = (Long) SecurityContextHolder.getContext().getAuthentication().getPrincipal();
+    CustomUserDetails userDetails = (CustomUserDetails) SecurityContextHolder.getContext().getAuthentication().getPrincipal();
+    Long userId = userDetails.getUserId();
     Long groupId = extractGroupId(joinPoint);
 
     if (!groupParticipantValidator.validateIsJoinedMember(groupId, userId)) {


### PR DESCRIPTION
## What
> 무엇을 작업했는지 간결하게 적습니다.

→ Security Context에서 userDetails를 뽑도록 변경하였습니다.

## Why
> 왜 이 작업을 했는지 설명합니다.

→ 기존 Long을 뽑도록 하였는데, 그 과정에서 type이 맞지 않아 오류가 발생했습니다.

## Changes
> 주요 변경사항을 적습니다.

→ AOP에서 사용하고 있던 (Long) 을 (userDetails)로 변경하였습니다.

## Related Issue
> 관련 이슈 번호를 연결합니다.

→ #139 
