### PR TITLE
hotfix: 일정 참석 거절 시 처리 안 되는 오류 해결 (#145)

### DIFF
--- a/src/main/java/kr/ai/nemo/domain/schedule/validator/ScheduleValidator.java
+++ b/src/main/java/kr/ai/nemo/domain/schedule/validator/ScheduleValidator.java
@@ -1,6 +1,5 @@
 package kr.ai.nemo.domain.schedule.validator;
 
-import java.time.LocalDateTime;
 import kr.ai.nemo.domain.schedule.domain.Schedule;
 import kr.ai.nemo.domain.schedule.domain.enums.ScheduleStatus;
 import kr.ai.nemo.domain.schedule.exception.ScheduleErrorCode;
@@ -39,7 +38,7 @@ public class ScheduleValidator {
   }
 
   public void validateScheduleStart(Schedule schedule) {
-    if (schedule.getStartAt().isBefore(LocalDateTime.now())) {
+    if (schedule.getStatus().equals(ScheduleStatus.CLOSED)) {
       throw new ScheduleException(ScheduleErrorCode.SCHEDULE_ALREADY_STARTED_OR_ENDED);
     }
   }

--- a/src/main/java/kr/ai/nemo/domain/scheduleparticipants/service/ScheduleParticipantsService.java
+++ b/src/main/java/kr/ai/nemo/domain/scheduleparticipants/service/ScheduleParticipantsService.java
@@ -83,7 +83,9 @@ public class ScheduleParticipantsService {
     if (currentStatus == ScheduleParticipantStatus.ACCEPTED && status == ScheduleParticipantStatus.REJECTED) {
       schedule.subtractCurrentUserCount();
       participant.reject();
-    } else if ((currentStatus == ScheduleParticipantStatus.PENDING || currentStatus == ScheduleParticipantStatus.REJECTED) 
+    } else if (currentStatus == ScheduleParticipantStatus.PENDING && status == ScheduleParticipantStatus.REJECTED) {
+      participant.reject();
+    } else if ((currentStatus == ScheduleParticipantStatus.PENDING || currentStatus == ScheduleParticipantStatus.REJECTED)
                && status == ScheduleParticipantStatus.ACCEPTED) {
       schedule.addCurrentUserCount();
       participant.accept();


### PR DESCRIPTION
## What
> 무엇을 작업했는지 간결하게 적습니다.

→ 일정 참석 여부를 처음 결정할 때 거절을 하면 상태값 변경이 되지 않는 오류를 수정합니다.

## Why
> 왜 이 작업을 했는지 설명합니다.

→ 해당 에러는 서비스 운영에 있어 사용자의 정보가 저장이 되지 않는 크리티컬한 에러이므로 hotfix로 해결하였습니다.

## Changes
> 주요 변경사항을 적습니다.

→ service 로직 내 조건문을 추가하여 일정 참석 여부 결정 전인 PENDING 상태에서 거절하여도 사용자의 상태값이 변경될 수 있도록 합니다.

## Related Issue
> 관련 이슈 번호를 연결합니다.

→ #145 
