### PR TITLE
fix: 모임 상세 조회 문제 해결

### DIFF
--- a/src/main/java/kr/ai/nemo/domain/group/repository/GroupRepository.java
+++ b/src/main/java/kr/ai/nemo/domain/group/repository/GroupRepository.java
@@ -53,11 +53,10 @@ public interface GroupRepository extends JpaRepository<Group, Long> {
   boolean existsByIdAndOwnerId(Long groupId, Long userId);
 
   @Query("""
-    SELECT DISTINCT g FROM Group g
-    LEFT JOIN g.groupTags gt
-    LEFT JOIN gt.tag t
-    WHERE g.status <> 'DISBANDED'
-    ORDER BY g.updatedAt DESC
+  SELECT g FROM Group g
+  LEFT JOIN FETCH g.groupTags gt
+  LEFT JOIN FETCH gt.tag t
+  WHERE g.status <> 'DISBANDED' AND g.id = :groupId
 """)
   Group findByIdGroupId(Long groupId);
 }


### PR DESCRIPTION
## What
> 무엇을 작업했는지 간결하게 적습니다.

→ 모임 상세 조회가 되지 않는 오류를 해결합니다.

## Why
> 왜 이 작업을 했는지 설명합니다.

→ JPA가 모임을 여러 개 조회하여 상세 조회가 되지 않는 크리티컬한 문제가 발생했습니다.

## Changes
> 주요 변경사항을 적습니다.

→ repository 내의 Query문을 수정하였습니다.