### PR TITLE
Infra: Clean Build로 변경

### DIFF
--- a/.github/workflows/v2-dev-cicd.yaml
+++ b/.github/workflows/v2-dev-cicd.yaml
@@ -2,7 +2,7 @@ name: Backend CI/CD for v2-dev
 
 on:
   push:
-    branches: [ develop ]
+    branches: [ develop, fix/clean-build ]
 
 jobs:
   build-and-deploy:

--- a/.github/workflows/v2-dev-cicd.yaml
+++ b/.github/workflows/v2-dev-cicd.yaml
@@ -45,7 +45,7 @@ jobs:
     - name: Gradle Build
       env:
         SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
-      run: ./gradlew build -x test --no-daemon
+      run: ./gradlew clean build -x test --no-daemon
 
     - name: Build and Push Docker Image
       run: |

--- a/.github/workflows/v2-dev-cicd.yaml
+++ b/.github/workflows/v2-dev-cicd.yaml
@@ -45,7 +45,9 @@ jobs:
     - name: Gradle Build
       env:
         SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
-      run: ./gradlew clean build -x test --no-daemon
+      run: |
+        ./gradlew clean build -x test --no-daemon
+        cp "$(ls -t build/libs/*.jar | head -n 1)" build/libs/app.jar
 
     - name: Build and Push Docker Image
       run: |


### PR DESCRIPTION
## What
> 무엇을 작업했는지 간결하게 적습니다.

- 백엔드 CI/CD 워크플로우에서 Gradle 빌드 시 캐싱 이슈로 인해 변경사항이 반영되지 않는 문제를 방지하기 위해 Clean Build를 적용하였습니다.

## Why
> 왜 이 작업을 했는지 설명합니다.

- GitHub Actions에서 캐싱된 *.jar 파일이 그대로 Docker 이미지에 포함되어, 코드 변경 사항이 반영되지 않는 문제가 발생했습니다. 이를 방지하기 위해 ./gradlew clean build를 통해 항상 최신 jar로 빌드하도록 수정했습니다.

## Changes
> 주요 변경사항을 적습니다.

- GitHub Actions 워크플로우에서 ./gradlew build → ./gradlew clean build -x test로 변경

## Related Issue
> 관련 이슈 번호를 연결합니다.
