### PR TITLE
Fix: OTLP 포트 설정 오류 설정 (4317->4318)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,4 +9,4 @@ COPY build/libs/*.jar app.jar
 
 EXPOSE 8080
 
-ENTRYPOINT ["java", "-javaagent:/app/opentelemetry-javaagent.jar", "-Dotel.service.name=backend-service", "-Dotel.exporter.otlp.endpoint=http://35.216.67.116:4317", "-Dotel.resource.attributes=deployment.environment=dev", "-jar", "app.jar"]
+ENTRYPOINT ["java", "-javaagent:/app/opentelemetry-javaagent.jar", "-Dotel.service.name=backend-service", "-Dotel.exporter.otlp.endpoint=http://35.216.67.116:4318", "-Dotel.resource.attributes=deployment.environment=dev", "-jar", "app.jar"]

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -58,7 +58,7 @@ management:
       export:
         enabled: true
     tracing:
-      endpoint: http://35.216.67.116:4317
+      endpoint: http://35.216.67.116:4318
       export:
         enabled: true
   endpoints:


### PR DESCRIPTION
## What
> 무엇을 작업했는지 간결하게 적습니다.

→ OTLP endpoint 포트 설정 오류 수정 및 application.yml 구성 반영

## Why
> 왜 이 작업을 했는지 설명합니다.

→기존에 OTLP endpoint를 4317 포트로 설정하여 OpenTelemetry trace export가 실패함.  
Spring Boot Actuator와 OTLP exporter는 기본적으로 HTTP/1.1을 사용하며, 이는 4318 포트를 통해 수신되어야 하므로 수정 필요.

## Changes
> 주요 변경사항을 적습니다.

→OTLP export 관련 설정 전체 점검 및 누락된 항목 보완  

## Related Issue
> 관련 이슈 번호를 연결합니다.

→
