### PR TITLE
null 캐싱으로 penetration 문제 해결

### DIFF
--- a/src/main/java/kr/ai/nemo/domain/group/dto/response/GroupDetailStaticInfo.java
+++ b/src/main/java/kr/ai/nemo/domain/group/dto/response/GroupDetailStaticInfo.java
@@ -23,6 +23,9 @@ public record GroupDetailStaticInfo(
     
     @Schema(description = "모임 장소")
     String location,
+
+    @Schema(description = "현재 참여 인원")
+    int currentUserCount,
     
     @Schema(description = "최대 참여 인원")
     int maxUserCount,
@@ -44,6 +47,7 @@ public record GroupDetailStaticInfo(
             group.getDescription(),
             group.getPlan(),
             group.getLocation(),
+            group.getCurrentUserCount(),
             group.getMaxUserCount(),
             group.getImageUrl(),
             tags,

--- a/src/main/java/kr/ai/nemo/domain/group/service/GroupCacheService.java
+++ b/src/main/java/kr/ai/nemo/domain/group/service/GroupCacheService.java
@@ -105,8 +105,6 @@ public class GroupCacheService {
     public void evictGroupDetailStatic(Long groupId) {
         GroupCacheKeys keys = new GroupCacheKeys(groupId);
         redisCacheService.del(keys.groupDetail);
-        redisCacheService.del(keys.nullCache);
-        redisCacheService.del(keys.disbanded);
         log.info("Cache Evict: groupId = {}", groupId);
     }
 }

--- a/src/main/java/kr/ai/nemo/domain/group/service/GroupCacheService.java
+++ b/src/main/java/kr/ai/nemo/domain/group/service/GroupCacheService.java
@@ -1,15 +1,23 @@
 package kr.ai.nemo.domain.group.service;
 
+import java.time.Duration;
 import java.util.List;
+import java.util.Optional;
 import kr.ai.nemo.domain.group.domain.Group;
 import kr.ai.nemo.domain.group.dto.response.GroupDetailStaticInfo;
+import kr.ai.nemo.domain.group.exception.GroupErrorCode;
+import kr.ai.nemo.domain.group.exception.GroupException;
 import kr.ai.nemo.domain.group.validator.GroupValidator;
+import kr.ai.nemo.global.redis.CacheKeyUtil;
+import kr.ai.nemo.global.redis.RedisCacheService;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.cache.annotation.CacheEvict;
 import org.springframework.cache.annotation.Cacheable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+@Slf4j
 @Service
 @RequiredArgsConstructor
 @Transactional(readOnly = true)
@@ -17,12 +25,46 @@ public class GroupCacheService {
 
     private final GroupValidator groupValidator;
     private final GroupTagService groupTagService;
+    private final RedisCacheService redisCacheService;
 
-    @Cacheable(value = "group-detail-static", key = "#groupId")
+    private static final Duration groupCacheExpire = Duration.ofMinutes(10);
+    private static final Duration nullGroupCacheExpire = Duration.ofMinutes(5);
     public GroupDetailStaticInfo getGroupDetailStatic(Long groupId) {
-        Group group = groupValidator.findByIdOrThrow(groupId);
-        List<String> tags = groupTagService.getTagNamesByGroupId(group.getId());
-        return GroupDetailStaticInfo.from(group, tags);
+        String groupCacheKey = CacheKeyUtil.key("group_detail", groupId);
+
+        Optional<GroupDetailStaticInfo> cacheResult = redisCacheService.get(groupCacheKey, GroupDetailStaticInfo.class);
+
+        if (cacheResult.isPresent()) {
+            log.info("Cache Hit: groupId = {}", groupId);
+            return cacheResult.get();
+        }
+
+        if (redisCacheService.isNullCached(groupCacheKey)) {
+            log.info("Cache Hit (null value): groupId = {}", groupId);
+            throw new GroupException(GroupErrorCode.GROUP_NOT_FOUND);
+        }
+
+
+        log.info("Cache Miss: groupId = {}", groupId);
+        return fetchAndCacheGroupDetail(groupId, groupCacheKey);
+    }
+
+
+    private GroupDetailStaticInfo fetchAndCacheGroupDetail(Long groupId, String groupCacheKey) {
+        try {
+            Group group = groupValidator.findByIdOrThrow(groupId);
+            List<String> tags = groupTagService.getTagNamesByGroupId(group.getId());
+            GroupDetailStaticInfo result = GroupDetailStaticInfo.from(group, tags);
+
+            redisCacheService.set(groupCacheKey, result, groupCacheExpire);
+            log.debug("Cache Set: groupId = {}", groupId);
+
+            return result;
+        } catch (Exception e) {
+            redisCacheService.set(groupCacheKey, null, nullGroupCacheExpire);
+            log.debug("Cache Set (null) groupId = {}", groupId);
+            throw e;
+        }
     }
 
     @CacheEvict(value = "group-detail-static", key = "#groupId")

--- a/src/main/java/kr/ai/nemo/domain/group/service/GroupQueryService.java
+++ b/src/main/java/kr/ai/nemo/domain/group/service/GroupQueryService.java
@@ -134,8 +134,7 @@ public class GroupQueryService {
   @Transactional(readOnly = true)
   public GroupDetailResponse detailGroup(Long groupId, CustomUserDetails customUserDetails) {
     GroupDetailStaticInfo staticInfo = groupCacheService.getGroupDetailStatic(groupId);
-    Group group = groupValidator.findByIdOrThrow(groupId);
-    Role role = groupParticipantValidator.checkUserRole(customUserDetails, group);
+    Role role = groupParticipantValidator.checkUserRole(customUserDetails, groupId);
     return new GroupDetailResponse(
         staticInfo.name(),
         staticInfo.category(),
@@ -143,7 +142,7 @@ public class GroupQueryService {
         staticInfo.description(),
         staticInfo.plan(),
         staticInfo.location(),
-        group.getCurrentUserCount(),
+        staticInfo.currentUserCount(),
         staticInfo.maxUserCount(),
         staticInfo.imageUrl(),
         staticInfo.tags(),

--- a/src/main/java/kr/ai/nemo/domain/groupparticipants/service/GroupParticipantsCommandService.java
+++ b/src/main/java/kr/ai/nemo/domain/groupparticipants/service/GroupParticipantsCommandService.java
@@ -3,6 +3,7 @@ package kr.ai.nemo.domain.groupparticipants.service;
 import java.time.LocalDateTime;
 import java.util.Optional;
 import java.util.concurrent.TimeUnit;
+import kr.ai.nemo.domain.group.service.GroupCacheService;
 import kr.ai.nemo.global.aop.logging.TimeTrace;
 import kr.ai.nemo.domain.auth.security.CustomUserDetails;
 import kr.ai.nemo.domain.group.domain.Group;
@@ -34,6 +35,7 @@ public class GroupParticipantsCommandService {
   private final GroupValidator groupValidator;
   private final GroupParticipantValidator groupParticipantValidator;
   private final RedisTemplate<String, String> redisTemplate;
+  private final GroupCacheService groupCacheService;
 
   @DistributedLock(
       key = "'cache::group::capacity::' + #groupId",
@@ -91,6 +93,7 @@ public class GroupParticipantsCommandService {
     if (isNewParticipant) {
       redisTemplate.opsForValue().increment(capacityKey);
       group.addCurrentUserCount();
+      groupCacheService.evictGroupDetailStatic(groupId);
     }
 
 // 5. 향후 일정에도 등록

--- a/src/test/java/kr/ai/nemo/domain/group/service/GroupQueryServiceTest.java
+++ b/src/test/java/kr/ai/nemo/domain/group/service/GroupQueryServiceTest.java
@@ -231,12 +231,12 @@ class GroupQueryServiceTest {
         CustomUserDetails customUserDetails = new CustomUserDetails(user);
 
         GroupDetailStaticInfo staticInfo = new GroupDetailStaticInfo(
-            "테스트 그룹", "스포츠", "요약", "설명", "계획", "서울", 10, "image.jpg", List.of("태그1"), "소유자"
+            "테스트 그룹", "스포츠", "요약", "설명", "계획", "서울", 5,10, "image.jpg", List.of("태그1"), "소유자"
         );
 
         given(groupCacheService.getGroupDetailStatic(group.getId())).willReturn(staticInfo);
         given(groupValidator.findByIdOrThrow(group.getId())).willReturn(group);
-        given(groupParticipantValidator.checkUserRole(customUserDetails, group)).willReturn(Role.MEMBER);
+        given(groupParticipantValidator.checkUserRole(customUserDetails, group.getId())).willReturn(Role.MEMBER);
 
         // when
         GroupDetailResponse result = groupQueryService.detailGroup(group.getId(), customUserDetails);
@@ -246,7 +246,7 @@ class GroupQueryServiceTest {
         assertThat(result.name()).isEqualTo("테스트 그룹");
         verify(groupCacheService).getGroupDetailStatic(group.getId());
         verify(groupValidator).findByIdOrThrow(group.getId());
-        verify(groupParticipantValidator).checkUserRole(customUserDetails, group);
+        verify(groupParticipantValidator).checkUserRole(customUserDetails, group.getId());
     }
 
     @Test

--- a/src/test/java/kr/ai/nemo/domain/groupparticipants/validator/GroupParticipantValidatorTest.java
+++ b/src/test/java/kr/ai/nemo/domain/groupparticipants/validator/GroupParticipantValidatorTest.java
@@ -122,7 +122,7 @@ class GroupParticipantValidatorTest {
         CustomUserDetails userDetails = new CustomUserDetails(owner);
 
         // when
-        Role result = groupParticipantValidator.checkUserRole(userDetails, group);
+        Role result = groupParticipantValidator.checkUserRole(userDetails, group.getId());
 
         // then
         assertThat(result).isEqualTo(Role.LEADER);
@@ -145,7 +145,7 @@ class GroupParticipantValidatorTest {
             .willReturn(true);
 
         // when
-        Role result = groupParticipantValidator.checkUserRole(userDetails, group);
+        Role result = groupParticipantValidator.checkUserRole(userDetails, group.getId());
 
         // then
         assertThat(result).isEqualTo(Role.MEMBER);
@@ -168,7 +168,7 @@ class GroupParticipantValidatorTest {
             .willReturn(false);
 
         // when
-        Role result = groupParticipantValidator.checkUserRole(userDetails, group);
+        Role result = groupParticipantValidator.checkUserRole(userDetails, group.getId());
 
         // then
         assertThat(result).isEqualTo(Role.NON_MEMBER);
@@ -183,7 +183,7 @@ class GroupParticipantValidatorTest {
         Group group = GroupFixture.createGroupWithId(1L, owner, "테스트 그룹");
 
         // when
-        Role result = groupParticipantValidator.checkUserRole(null, group);
+        Role result = groupParticipantValidator.checkUserRole(null, group.getId());
 
         // then
         assertThat(result).isEqualTo(Role.GUEST);


### PR DESCRIPTION
## What
> 무엇을 작업했는지 간결하게 적습니다.

→ 없는 모임이나 해체된 모임이 캐싱되지 않아서 발생할 수 있는 penetration 문제를 해결합니다.

## Why
> 왜 이 작업을 했는지 설명합니다.

→ 해체된 모임이나 없는 모임을 의도적으로 여러 번 접근할 경우 DB에 부하가 발생하기 때문에 이를 해결합니다.

## Changes
> 주요 변경사항을 적습니다.

→ 없는 모임은 null, 해체된 모임은 disbanded로 캐싱하여 redis에 저장합니다.

## Related Issue
> 관련 이슈 번호를 연결합니다.

→ #189 
