### PR TITLE
websocket 도입, 캐싱 문제 해결

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -50,7 +50,8 @@ dependencies {
     implementation("org.springframework.boot:spring-boot-starter-webflux")
     implementation("org.springframework.retry:spring-retry")
     implementation("org.redisson:redisson-spring-boot-starter:$redissonVersion")
-    
+    implementation("org.springframework.boot:spring-boot-starter-websocket")
+
     // Jackson JSR310 모듈 명시적 추가
     implementation("com.fasterxml.jackson.datatype:jackson-datatype-jsr310")
 

--- a/src/main/java/kr/ai/nemo/domain/group/domain/enums/AiMessageType.java
+++ b/src/main/java/kr/ai/nemo/domain/group/domain/enums/AiMessageType.java
@@ -1,0 +1,21 @@
+package kr.ai.nemo.domain.group.domain.enums;
+
+import lombok.Getter;
+
+@Getter
+public enum AiMessageType {
+  CREATE_QUESTION("CREATE_QUESTION"),
+  QUESTION_CHUNK("QUESTION_CHUNK"),
+  QUESTION_OPTIONS("QUESTION_OPTIONS"),
+  RECOMMEND_REQUEST("RECOMMEND_REQUEST"),
+  RECOMMEND_ID("RECOMMEND_ID"),
+  RECOMMEND_REASON("RECOMMEND_REASON"),
+  RECOMMEND_DONE("RECOMMEND_DONE"),
+  ERROR("ERROR");
+
+  private final String value;
+
+  AiMessageType(String value) {
+    this.value = value;
+  }
+}

--- a/src/main/java/kr/ai/nemo/domain/group/dto/websocket/request/GroupRecommendQuestionRequest.java
+++ b/src/main/java/kr/ai/nemo/domain/group/dto/websocket/request/GroupRecommendQuestionRequest.java
@@ -1,0 +1,12 @@
+package kr.ai.nemo.domain.group.dto.websocket.request;
+
+public record GroupRecommendQuestionRequest(
+    String type,
+    Payload payload
+) {
+  public record Payload(
+      String sessionId,
+      Long userId,
+      String answer
+  ) {}
+}

--- a/src/main/java/kr/ai/nemo/domain/group/dto/websocket/request/GroupRecommendRequest.java
+++ b/src/main/java/kr/ai/nemo/domain/group/dto/websocket/request/GroupRecommendRequest.java
@@ -1,0 +1,16 @@
+package kr.ai.nemo.domain.group.dto.websocket.request;
+
+import java.util.List;
+import kr.ai.nemo.domain.group.dto.request.GroupAiQuestionRecommendRequest.ContextLog;
+
+public record GroupRecommendRequest(
+    String type,
+    RequestPayload payload
+) {
+  public record RequestPayload (
+      String sessionId,
+      Long userId,
+      List<ContextLog> messages
+  ) {
+  }
+}

--- a/src/main/java/kr/ai/nemo/domain/group/dto/websocket/response/GroupRecommendGroupIdResponse.java
+++ b/src/main/java/kr/ai/nemo/domain/group/dto/websocket/response/GroupRecommendGroupIdResponse.java
@@ -1,0 +1,11 @@
+package kr.ai.nemo.domain.group.dto.websocket.response;
+
+public record GroupRecommendGroupIdResponse(
+    String type,
+    GroupIdPayload payload
+) {
+  public record GroupIdPayload(
+      String sessionId,
+      Long groupId
+  ) {}
+}

--- a/src/main/java/kr/ai/nemo/domain/group/dto/websocket/response/GroupRecommendOptionResponse.java
+++ b/src/main/java/kr/ai/nemo/domain/group/dto/websocket/response/GroupRecommendOptionResponse.java
@@ -1,0 +1,13 @@
+package kr.ai.nemo.domain.group.dto.websocket.response;
+
+import java.util.List;
+
+public record GroupRecommendOptionResponse(
+    String type,
+    Payload payload
+) {
+  public record Payload(
+      String sessionId,
+      List<String> options
+  ) {}
+}

--- a/src/main/java/kr/ai/nemo/domain/group/dto/websocket/response/GroupRecommendQuestionResponse.java
+++ b/src/main/java/kr/ai/nemo/domain/group/dto/websocket/response/GroupRecommendQuestionResponse.java
@@ -1,0 +1,11 @@
+package kr.ai.nemo.domain.group.dto.websocket.response;
+
+public record GroupRecommendQuestionResponse(
+    String type,
+    Payload payload
+) {
+  public record Payload(
+      String sessionId,
+      String text
+  ) {}
+}

--- a/src/main/java/kr/ai/nemo/domain/group/dto/websocket/response/GroupRecommendReasonResponse.java
+++ b/src/main/java/kr/ai/nemo/domain/group/dto/websocket/response/GroupRecommendReasonResponse.java
@@ -1,0 +1,11 @@
+package kr.ai.nemo.domain.group.dto.websocket.response;
+
+public record GroupRecommendReasonResponse(
+    String type,
+    ReasonPayload payload
+) {
+  public record ReasonPayload(
+      String sessionId,
+      String reason
+  ) {}
+}

--- a/src/main/java/kr/ai/nemo/domain/group/repository/GroupRepository.java
+++ b/src/main/java/kr/ai/nemo/domain/group/repository/GroupRepository.java
@@ -79,6 +79,8 @@ public interface GroupRepository extends JpaRepository<Group, Long> {
   LEFT JOIN FETCH g.groupTags gt
   LEFT JOIN FETCH gt.tag
   WHERE g.id IN :ids
+  ORDER BY g.updatedAt DESC
+
 """)
   List<Group> findGroupsWithTagsByIds(@Param("ids") List<Long> ids);
 

--- a/src/main/java/kr/ai/nemo/domain/group/service/GroupCacheKeyUtil.java
+++ b/src/main/java/kr/ai/nemo/domain/group/service/GroupCacheKeyUtil.java
@@ -1,0 +1,21 @@
+package kr.ai.nemo.domain.group.service;
+
+import kr.ai.nemo.domain.group.dto.request.GroupSearchRequest;
+import kr.ai.nemo.global.redis.CacheKeyUtil;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class GroupCacheKeyUtil {
+
+  public String getGroupListKey(GroupSearchRequest request, Pageable pageable) {
+    return CacheKeyUtil.key(
+        "group-list",
+        "category", request.getCategory(),
+        "page", pageable.getPageNumber(),
+        "size", pageable.getPageSize()
+    );
+  }
+}

--- a/src/main/java/kr/ai/nemo/domain/group/service/GroupCacheKeyUtil.java
+++ b/src/main/java/kr/ai/nemo/domain/group/service/GroupCacheKeyUtil.java
@@ -1,21 +1,16 @@
 package kr.ai.nemo.domain.group.service;
 
-import kr.ai.nemo.domain.group.dto.request.GroupSearchRequest;
 import kr.ai.nemo.global.redis.CacheKeyUtil;
 import lombok.RequiredArgsConstructor;
-import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Component;
 
 @Component
 @RequiredArgsConstructor
 public class GroupCacheKeyUtil {
 
-  public String getGroupListKey(GroupSearchRequest request, Pageable pageable) {
+  public String getGroupListKey() {
     return CacheKeyUtil.key(
-        "group-list",
-        "category", request.getCategory(),
-        "page", pageable.getPageNumber(),
-        "size", pageable.getPageSize()
+        "group-list"
     );
   }
 }

--- a/src/main/java/kr/ai/nemo/domain/group/service/GroupCacheService.java
+++ b/src/main/java/kr/ai/nemo/domain/group/service/GroupCacheService.java
@@ -25,6 +25,7 @@ public class GroupCacheService {
     private final GroupRepository groupRepository;
     private final GroupTagService groupTagService;
     private final RedisCacheService redisCacheService;
+    private final GroupCacheKeyUtil groupCacheKeyUtil;
 
     private static final Duration groupCacheExpire = Duration.ofMinutes(10);
     private static final Duration errorCacheExpire = Duration.ofMinutes(5);
@@ -106,5 +107,16 @@ public class GroupCacheService {
         GroupCacheKeys keys = new GroupCacheKeys(groupId);
         redisCacheService.del(keys.groupDetail);
         log.info("Cache Evict: groupId = {}", groupId);
+    }
+
+    public void deleteGroupListCaches() {
+        try {
+            String keys = groupCacheKeyUtil.getGroupListKey();
+            if (keys != null && !keys.isEmpty()) {
+                redisCacheService.del(keys);
+            }
+        } catch (Exception e) {
+            log.error("Failed to delete group-list caches: {}", e.getMessage());
+        }
     }
 }

--- a/src/main/java/kr/ai/nemo/domain/group/service/GroupCommandService.java
+++ b/src/main/java/kr/ai/nemo/domain/group/service/GroupCommandService.java
@@ -115,6 +115,7 @@ public class GroupCommandService {
     groupCacheService.evictGroupDetailStatic(groupId);
   }
 
+  @CacheEvict(value = "group-list", allEntries = true)
   @TimeTrace
   @Transactional
   public void updateGroupImage(Long groupId, Long userId, UpdateGroupImageRequest request) {
@@ -123,6 +124,7 @@ public class GroupCommandService {
     group.setImageUrl(imageService.updateImage(group.getImageUrl(), request.imageUrl()));
     group.setUpdatedAt(LocalDateTime.now());
     groupCacheService.evictGroupDetailStatic(groupId);
+    groupCacheService.deleteGroupListCaches();
   }
 
   @TimeTrace

--- a/src/main/java/kr/ai/nemo/domain/group/service/GroupCommandService.java
+++ b/src/main/java/kr/ai/nemo/domain/group/service/GroupCommandService.java
@@ -60,6 +60,7 @@ public class GroupCommandService {
   private final GroupValidator groupValidator;
   private final GroupParticipantValidator groupParticipantValidator;
   private final RedisCacheService redisCacheService;
+  private final GroupWebsocketService groupWebsocketService;
 
   @TimeTrace
   @Transactional
@@ -149,7 +150,16 @@ public class GroupCommandService {
           ChatMessage.class, CacheConstants.CHATBOT_SESSION_TTL);
     }
 
-    GroupChatbotQuestionResponse aiResponse = aiClient.recommendGroupQuestion(aiRequest, sessionId);
+    /*
+     기존 코드
+     GroupChatbotQuestionResponse aiResponse = aiClient.recommendGroupQuestion(aiRequest, sessionId);
+     */
+
+    GroupChatbotQuestionResponse aiResponse = groupWebsocketService.sendQuestionToAI(
+        request,
+        userId,
+        sessionId
+    );
 
     // AI 응답 저장
     ChatMessage aiMsg = new ChatMessage(ChatbotRole.AI, aiResponse.question(),

--- a/src/main/java/kr/ai/nemo/domain/group/service/GroupCommandService.java
+++ b/src/main/java/kr/ai/nemo/domain/group/service/GroupCommandService.java
@@ -93,14 +93,13 @@ public class GroupCommandService {
         .status(GroupStatus.ACTIVE)
         .build();
 
-    Group savedGroup = groupRepository.save(group);
+    Group savedGroup = groupRepository.saveAndFlush(group);
 
     if (request.tags() != null && !request.tags().isEmpty()) {
       groupTagService.assignTags(savedGroup, request.tags());
     }
 
-    groupParticipantsCommandService.applyToGroup(savedGroup.getId(), userDetails, Role.LEADER,
-        Status.JOINED);
+    groupParticipantsCommandService.createToGroupLeader(savedGroup, userDetails.getUser());
 
     List<String> tags = groupTagService.getTagNamesByGroupId(savedGroup.getId());
 

--- a/src/main/java/kr/ai/nemo/domain/group/service/GroupQueryService.java
+++ b/src/main/java/kr/ai/nemo/domain/group/service/GroupQueryService.java
@@ -56,7 +56,7 @@ public class GroupQueryService {
   @TimeTrace
   @Transactional(readOnly = true)
   public GroupListResponse getGroups(GroupSearchRequest request, Pageable pageable) {
-    String cacheKey = groupCacheKeyUtil.getGroupListKey(request, pageable);
+    String cacheKey = groupCacheKeyUtil.getGroupListKey();
 
     Optional<GroupListResponse> cached = redisCacheService.get(cacheKey, GroupListResponse.class);
     if (cached.isPresent()) {
@@ -83,7 +83,7 @@ public class GroupQueryService {
   }
 
   @DistributedLock(
-      key = "T(kr.ai.nemo.domain.group.service.GroupCacheKeyUtil).getGroupListKey(#request.category, #pageable pageable)",
+      key = "T(kr.ai.nemo.domain.group.service.GroupCacheKeyUtil).getGroupListKey()",
       waitTime = 3,
       leaseTime = 5,
       timeUnit = TimeUnit.SECONDS

--- a/src/main/java/kr/ai/nemo/domain/group/service/GroupQueryService.java
+++ b/src/main/java/kr/ai/nemo/domain/group/service/GroupQueryService.java
@@ -50,6 +50,7 @@ public class GroupQueryService {
   private final RedisCacheService redisCacheService;
   private final AiGroupService aiGroupService;
   private final GroupCacheService groupCacheService;
+  private final GroupWebsocketService groupWebsocketService;
 
   @TimeTrace
   @Transactional(readOnly = true)
@@ -219,7 +220,11 @@ public class GroupQueryService {
     GroupAiQuestionRecommendRequest aiRequest = new GroupAiQuestionRecommendRequest(userId,
         contextLogs);
 
-    GroupAiRecommendResponse aiResponse = aiGroupService.recommendGroup(aiRequest, sessionId);
+    /*
+        GroupAiRecommendResponse aiResponse = aiGroupService.recommendGroup(aiRequest, sessionId);
+
+     */
+    GroupAiRecommendResponse aiResponse = groupWebsocketService.sendRecommendToAI(aiRequest, sessionId);
     Group group = groupValidator.findByIdOrThrow(aiResponse.groupId());
 
     return new GroupRecommendResponse(GroupDto.from(group), aiResponse.reason());

--- a/src/main/java/kr/ai/nemo/domain/group/service/GroupWebsocketService.java
+++ b/src/main/java/kr/ai/nemo/domain/group/service/GroupWebsocketService.java
@@ -1,0 +1,217 @@
+package kr.ai.nemo.domain.group.service;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.net.URI;
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.TimeUnit;
+import kr.ai.nemo.domain.group.domain.enums.AiMessageType;
+import kr.ai.nemo.domain.group.dto.request.GroupAiQuestionRecommendRequest;
+import kr.ai.nemo.domain.group.dto.request.GroupChatbotQuestionRequest;
+import kr.ai.nemo.domain.group.dto.websocket.request.GroupRecommendRequest;
+import kr.ai.nemo.domain.group.dto.response.GroupAiRecommendResponse;
+import kr.ai.nemo.domain.group.dto.response.GroupChatbotQuestionResponse;
+import kr.ai.nemo.domain.group.dto.websocket.request.GroupRecommendQuestionRequest;
+import kr.ai.nemo.domain.group.dto.websocket.request.GroupRecommendQuestionRequest.Payload;
+import kr.ai.nemo.domain.group.dto.websocket.request.GroupRecommendRequest.RequestPayload;
+import kr.ai.nemo.domain.group.dto.websocket.response.GroupRecommendGroupIdResponse;
+import kr.ai.nemo.domain.group.dto.websocket.response.GroupRecommendOptionResponse;
+import kr.ai.nemo.domain.group.dto.websocket.response.GroupRecommendQuestionResponse;
+import kr.ai.nemo.domain.group.dto.websocket.response.GroupRecommendReasonResponse;
+import kr.ai.nemo.global.error.code.CommonErrorCode;
+import kr.ai.nemo.global.error.exception.CustomException;
+import lombok.NonNull;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.web.socket.TextMessage;
+import org.springframework.web.socket.WebSocketHttpHeaders;
+import org.springframework.web.socket.WebSocketSession;
+import org.springframework.web.socket.client.WebSocketClient;
+import org.springframework.web.socket.client.standard.StandardWebSocketClient;
+import org.springframework.web.socket.handler.TextWebSocketHandler;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class GroupWebsocketService extends TextWebSocketHandler {
+
+  private final ConcurrentHashMap<String, WebSocketSession> aiConnctions = new ConcurrentHashMap<>();
+  private final ConcurrentHashMap<String, CompletableFuture<GroupChatbotQuestionResponse>> pendingRequests = new ConcurrentHashMap<>();
+  private final ConcurrentHashMap<String, CompletableFuture<GroupAiRecommendResponse>> pendingRecommendRequests = new ConcurrentHashMap<>();
+  private final ConcurrentHashMap<String, StringBuilder> questionCollectors = new ConcurrentHashMap<>();
+  private final ConcurrentHashMap<String, StringBuilder> reasonCollectors = new ConcurrentHashMap<>();
+  private final ConcurrentHashMap<String, List<String>> optionsCollectors = new ConcurrentHashMap<>();
+  private final ConcurrentHashMap<String, Long> groupIdCollectors = new ConcurrentHashMap<>();
+
+  private final ObjectMapper objectMapper;
+
+  // session을 만들거나 해제
+  public WebSocketSession getOrCreateSessionConnection(String sessionId) {
+    return aiConnctions.computeIfAbsent(sessionId, this::createSessionConnection);
+  }
+
+  private WebSocketSession createSessionConnection(String sessionId) {
+    try {
+      WebSocketClient client = new StandardWebSocketClient();
+      URI uri = URI.create("ws://172.20.5.180:8000/ai/v2/chatbot");
+
+      WebSocketHttpHeaders headers = new WebSocketHttpHeaders();
+      headers.add("X-CHATBOT-KEY", sessionId);
+
+      CompletableFuture<WebSocketSession> sessionFuture = client.execute(this, headers, uri);
+      WebSocketSession session = sessionFuture.get(10, TimeUnit.SECONDS);
+
+      log.info("Created websocket session: {}", sessionId);
+      return session;
+    } catch (Exception e) {
+      log.error("failed to create AI connection for sessionId {}", sessionId, e);
+      throw new CustomException(CommonErrorCode.AI_SERVER_CONNECTION_FAILED);
+    }
+  }
+
+  // session 종료
+  public void closeSessionConnection(String sessionId) {
+    WebSocketSession session = aiConnctions.remove(sessionId);
+    if (session != null && session.isOpen()) {
+      try {
+        session.close();
+        log.info("AI Websocket session closed for sessionId: {}", sessionId);
+      } catch (Exception e) {
+        log.error("Error closing AI Websocket sessionId: {}", sessionId, e);
+      }
+    }
+    cleanupSession(sessionId);
+  }
+
+  // 질문 생성 요청
+  public GroupChatbotQuestionResponse sendQuestionToAI(GroupChatbotQuestionRequest request, Long userId,
+      String sessionId) {
+    WebSocketSession session = getOrCreateSessionConnection(sessionId);
+
+    try {
+      CompletableFuture<GroupChatbotQuestionResponse> future = new CompletableFuture<>();
+      pendingRequests.put(sessionId, future);
+
+      GroupRecommendQuestionRequest aiRequest =
+          new GroupRecommendQuestionRequest(
+              AiMessageType.CREATE_QUESTION.getValue(), new Payload(sessionId, userId, request.answer()));
+
+      sendAndWaitQuestionAndOptions(session, aiRequest);
+      GroupChatbotQuestionResponse response = future.get(30, TimeUnit.SECONDS);
+
+      return response;
+    } catch (Exception e) {
+      log.error("Error sending question to AI Websocket sessionId: {}", sessionId, e);
+      cleanupSession(sessionId);
+      throw new CustomException(CommonErrorCode.AI_SERVER_CONNECTION_FAILED);
+    }
+  }
+
+  // 모임 추천 요청
+  public GroupAiRecommendResponse sendRecommendToAI(GroupAiQuestionRecommendRequest request,
+      String sessionId) {
+    WebSocketSession session = getOrCreateSessionConnection(sessionId);
+
+    try {
+      CompletableFuture<GroupAiRecommendResponse> future = new CompletableFuture<>();
+      pendingRecommendRequests.put(sessionId, future);
+
+      GroupRecommendRequest aiRequest =
+          new GroupRecommendRequest(
+              AiMessageType.RECOMMEND_REQUEST.getValue(), new RequestPayload(sessionId, request.userId(), request.messages()));
+
+      sendAndWaitRecommend(session, aiRequest);
+      GroupAiRecommendResponse response = future.get(30, TimeUnit.SECONDS);
+
+      closeSessionConnection(sessionId);
+      return response;
+    } catch (Exception e) {
+      log.error("Error sending question to AI Websocket sessionId: {}", sessionId, e);
+      cleanupSession(sessionId);
+      throw new CustomException(CommonErrorCode.AI_SERVER_CONNECTION_FAILED);
+    }
+  }
+
+  private void sendAndWaitQuestionAndOptions(WebSocketSession session, GroupRecommendQuestionRequest aiRequest) throws Exception {
+    session.sendMessage(new TextMessage(objectMapper.writeValueAsString(aiRequest)));
+  }
+
+  private void sendAndWaitRecommend(WebSocketSession session, GroupRecommendRequest aiRequest) throws Exception {
+    session.sendMessage(new TextMessage(objectMapper.writeValueAsString(aiRequest)));
+  }
+
+  private void cleanupSession(String sessionId) {
+
+  }
+
+  @Override
+  protected void handleTextMessage(@NonNull WebSocketSession session, @NonNull TextMessage message) throws Exception {
+    // 1. 일단 공통으로 파싱
+    String payload = message.getPayload();
+    log.info("Received AI message: {}", payload);
+
+    // 2. type만 먼저 확인
+    JsonNode jsonNode = objectMapper.readTree(payload);
+    String messageType = jsonNode.get("type").asText();
+    String sessionId = jsonNode.get("payload").get("sessionId").asText();
+
+    log.info("Message type: {}, sessionId: {}", messageType, sessionId);
+
+    switch (messageType) {
+      case "QUESTION_CHUNK" -> {
+        GroupRecommendQuestionResponse response = objectMapper.readValue(payload, GroupRecommendQuestionResponse.class);
+        questionCollectors.computeIfAbsent(sessionId, k -> new StringBuilder())
+            .append(response.payload().text());
+      }
+
+      case "QUESTION_OPTIONS" -> {
+        GroupRecommendOptionResponse optionResponse = objectMapper.readValue(payload, GroupRecommendOptionResponse.class);
+        List<String> optionsList = optionResponse.payload().options(); // 실제 필드명에 따라
+        optionsCollectors.put(sessionId, optionsList);
+
+        // 질문 + 선택지 모두 완료
+        completeAiResponse(sessionId);
+      }
+
+      case "RECOMMEND_ID" -> {
+        GroupRecommendGroupIdResponse response = objectMapper.readValue(payload, GroupRecommendGroupIdResponse.class);
+        Long groupId = response.payload().groupId();
+        groupIdCollectors.put(sessionId, groupId);
+      }
+
+      case "RECOMMEND_REASON" -> {
+        GroupRecommendReasonResponse response = objectMapper.readValue(payload, GroupRecommendReasonResponse.class);
+        reasonCollectors.computeIfAbsent(sessionId, k -> new StringBuilder())
+            .append(response.payload().reason());
+      }
+
+      case "RECOMMEND_DONE" ->
+        completeRecommendResponse(sessionId);
+    }
+  }
+
+  private void completeAiResponse(String sessionId) {
+    String completeQuestion = questionCollectors.remove(sessionId).toString();
+    List<String> options = optionsCollectors.remove(sessionId);
+
+    CompletableFuture<GroupChatbotQuestionResponse> future = pendingRequests.remove(sessionId);
+    if (future != null) {
+      GroupChatbotQuestionResponse response = new GroupChatbotQuestionResponse(completeQuestion, options);
+      future.complete(response);
+    }
+  }
+
+  private void completeRecommendResponse(String sessionId) {
+    Long completeGroupId = groupIdCollectors.remove(sessionId);
+    String completeReason  = reasonCollectors.remove(sessionId).toString();
+
+    CompletableFuture<GroupAiRecommendResponse> future = pendingRecommendRequests.remove(sessionId);
+    if (future != null) {
+      GroupAiRecommendResponse response = new GroupAiRecommendResponse(completeGroupId, completeReason, null);
+      future.complete(response);
+    }
+  }
+}

--- a/src/main/java/kr/ai/nemo/domain/groupparticipants/service/GroupParticipantsCommandService.java
+++ b/src/main/java/kr/ai/nemo/domain/groupparticipants/service/GroupParticipantsCommandService.java
@@ -47,35 +47,52 @@ public class GroupParticipantsCommandService {
   @Transactional
   public void applyToGroup(Long groupId, CustomUserDetails userDetails, Role role, Status status) {
     User user = userDetails.getUser();
+    log.info("applyToGroup: user={} group = {}", user, groupId);
     Group group = groupValidator.findByIdOrThrow(groupId);
 
     String capacityKey = CacheKeyUtil.key("group", "capacity", groupId);
     int maxCapacity = group.getMaxUserCount();
 
-    // 1. Redis 초기화
-    String rawValue = redisTemplate.opsForValue().get(capacityKey);
-    Long cachedCount = (rawValue != null) ? Long.parseLong(rawValue) : null;
-    if (cachedCount == null) {
-      cachedCount = (long) group.getCurrentUserCount();
-      redisTemplate.opsForValue().set(capacityKey, String.valueOf(cachedCount));
-    }
+    Long currentCount = getCachedOrLoadGroupCapacity(capacityKey, group);
 
-// 2. 먼저 DB 기준으로 현재 인원 확인
-    if (cachedCount >= maxCapacity) {
+    if (currentCount >= maxCapacity) {
       log.info("모임이 가득 찼습니다. userId={}, groupId={}", user.getId(), groupId);
       throw new GroupException(GroupErrorCode.GROUP_FULL);
     }
 
-// 3. 참여자 처리
-    Optional<GroupParticipants> participant =
-        groupParticipantsRepository.findByGroupIdAndUserId(groupId, user.getId());
+    boolean isNewParticipant = saveOrRejoinParticipant(user, group, role, status);
 
-    boolean isNewParticipant = false;
+    if (isNewParticipant) {
+      incrementCapacity(capacityKey);
+      group.addCurrentUserCount();
+      groupCacheService.evictGroupDetailStatic(groupId);
+    }
+
+    scheduleParticipantsService.addParticipantToUpcomingSchedules(group, user);
+  }
+
+  private Long getCachedOrLoadGroupCapacity(String key, Group group) {
+    String rawValue = redisTemplate.opsForValue().get(key);
+    if (rawValue != null) return Long.parseLong(rawValue);
+
+    Long count = (long) group.getCurrentUserCount();
+    redisTemplate.opsForValue().set(key, String.valueOf(count));
+    return count;
+  }
+
+  private void incrementCapacity(String key) {
+    redisTemplate.opsForValue().increment(key);
+  }
+
+  private boolean saveOrRejoinParticipant(User user, Group group, Role role, Status status) {
+    Optional<GroupParticipants> participant =
+        groupParticipantsRepository.findByGroupIdAndUserId(group.getId(), user.getId());
 
     if (participant.isPresent()) {
-      GroupParticipants groupParticipant = participant.get();
-      groupParticipantValidator.validateJoinedParticipant(groupParticipant);
-      groupParticipant.rejoin();
+      GroupParticipants existing = participant.get();
+      groupParticipantValidator.validateJoinedParticipant(existing);
+      existing.rejoin();
+      return false;
     } else {
       GroupParticipants newParticipant = GroupParticipants.builder()
           .user(user)
@@ -84,22 +101,24 @@ public class GroupParticipantsCommandService {
           .status(status)
           .appliedAt(LocalDateTime.now())
           .build();
-
       groupParticipantsRepository.save(newParticipant);
-      isNewParticipant = true;
+      return true;
     }
-
-// 4. 확정된 경우만 Redis & DB 증가
-    if (isNewParticipant) {
-      redisTemplate.opsForValue().increment(capacityKey);
-      group.addCurrentUserCount();
-      groupCacheService.evictGroupDetailStatic(groupId);
-    }
-
-// 5. 향후 일정에도 등록
-    scheduleParticipantsService.addParticipantToUpcomingSchedules(group, user);
   }
 
+  @TimeTrace
+  @Transactional
+  public void createToGroupLeader(Group group, User user) {
+    GroupParticipants newParticipant = GroupParticipants.builder()
+        .user(user)
+        .group(group)
+        .role(Role.LEADER)
+        .status(Status.JOINED)
+        .appliedAt(LocalDateTime.now())
+        .build();
+    groupParticipantsRepository.save(newParticipant);
+    group.addCurrentUserCount();
+  }
 
   @TimeTrace
   @Transactional

--- a/src/main/java/kr/ai/nemo/domain/groupparticipants/service/GroupParticipantsCommandService.java
+++ b/src/main/java/kr/ai/nemo/domain/groupparticipants/service/GroupParticipantsCommandService.java
@@ -65,10 +65,11 @@ public class GroupParticipantsCommandService {
     if (isNewParticipant) {
       incrementCapacity(capacityKey);
       group.addCurrentUserCount();
-      groupCacheService.evictGroupDetailStatic(groupId);
     }
 
     scheduleParticipantsService.addParticipantToUpcomingSchedules(group, user);
+    groupCacheService.evictGroupDetailStatic(groupId);
+    groupCacheService.deleteGroupListCaches();
   }
 
   private Long getCachedOrLoadGroupCapacity(String key, Group group) {
@@ -128,6 +129,8 @@ public class GroupParticipantsCommandService {
     groupParticipantValidator.checkOwner(participants);
     participants.setStatus(Status.KICKED);
     group.decreaseCurrentUserCount();
+    groupCacheService.evictGroupDetailStatic(groupId);
+    groupCacheService.deleteGroupListCaches();
   }
 
   @TimeTrace
@@ -138,5 +141,7 @@ public class GroupParticipantsCommandService {
     groupParticipantValidator.checkOwner(participants);
     participants.setStatus(Status.WITHDRAWN);
     group.decreaseCurrentUserCount();
+    groupCacheService.evictGroupDetailStatic(groupId);
+    groupCacheService.deleteGroupListCaches();
   }
 }


### PR DESCRIPTION
## What
> 무엇을 작업했는지 간결하게 적습니다.

→ BE - AI 사이에 WebClient에서 WebSocket으로 변경합니다.
→ 모임 list 조회 시 무효화가 이루어지지 않아서 잘못된 값이 캐싱되는 문제를 해결합니다.

## Why
> 왜 이 작업을 했는지 설명합니다.

→ 챗봇에 진입 시 사용자에게 처음으로 보여지는 액션을 줄이기 위해 AI에게 Chuck 단위로 텍스트를 전달받습니다.
→ 모임을 수정하거나 삭제해도 모임 list에는 반영이 되지 않는 문제를 해결하기 위함입니다.

## Changes
> 주요 변경사항을 적습니다.

→ 기존 사용하고 있던 WebClient를 사용하지 않습니다. (추후 WebSocket이 안정화되면 해당 logic들은 제거할 예정입니다.)
→ cache 키를 별도의 service에서 관리하여 여러 군데 분산되어있는 key를 모읍니다.

## Related Issue
> 관련 이슈 번호를 연결합니다.

→ #191 #192
