### PR TITLE
Fix: use gRPC (4317) for JVM metric export to Signoz 

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,4 +9,4 @@ COPY build/libs/*.jar app.jar
 
 EXPOSE 8080
 
-ENTRYPOINT ["java", "-javaagent:/app/opentelemetry-javaagent.jar", "-Dotel.service.name=backend-service", "-Dotel.exporter.otlp.endpoint=http://35.216.67.116:4318", "-Dotel.exporter.otlp.protocol=http/protobuf", "-Dotel.resource.attributes=deployment.environment=dev", "-jar", "app.jar"]
+ENTRYPOINT ["java", "-javaagent:/app/opentelemetry-javaagent.jar", "-Dotel.service.name=backend-service", "-Dotel.exporter.otlp.endpoint=http://35.216.67.116:4317", "-Dotel.exporter.otlp.protocol=grpc", "-Dotel.resource.attributes=deployment.environment=dev", "-jar", "app.jar"]


### PR DESCRIPTION
## What
> 무엇을 작업했는지 간결하게 적습니다.

- JVM 메트릭이 SigNoz에 수집되지 않던 문제를 해결하기 위해 Java Agent 설정을 수정했습니다.

## Why
> 왜 이 작업을 했는지 설명합니다.

-기존에는 OTLP HTTP 포트(4318)를 사용하는 설정이었지만, Java Agent는 기본적으로 gRPC 방식(4317)을 사용해야 하며, HTTP 전송 시 metrics endpoint가 Collector에서 404 오류를 반환하고 있었습니다.

## Changes
> 주요 변경사항을 적습니다.

- Dockerfile ENTRYPOINT 수정:
  - `-Dotel.exporter.otlp.endpoint=http://35.216.67.116:4317` 로 변경
  - `-Dotel.exporter.otlp.protocol=grpc` 로 변경
- `application.yml`은 변경 없음 (Spring Actuator 기반 metrics/traces는 그대로 작동하므로)

## Related Issue
> 관련 이슈 번호를 연결합니다.

→https://github.com/100-hours-a-week/6-nemo-be/issues/179#issue-3175466768