### PR TITLE
Fix: enable JVM GC Metric in Dockerfile 

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,4 +9,4 @@ COPY build/libs/*.jar app.jar
 
 EXPOSE 8080
 
-ENTRYPOINT ["java", "-javaagent:/app/opentelemetry-javaagent.jar", "-Dotel.service.name=backend-service", "-Dotel.exporter.otlp.endpoint=http://35.216.67.116:4317", "-Dotel.exporter.otlp.protocol=grpc", "-Dotel.resource.attributes=deployment.environment=dev", "-jar", "app.jar"]
+ENTRYPOINT ["java", "-javaagent:/app/opentelemetry-javaagent.jar", "-Dotel.service.name=backend-service", "-Dotel.exporter.otlp.endpoint=http://35.216.67.116:4317", "-Dotel.exporter.otlp.protocol=grpc", "-Dotel.resource.attributes=deployment.environment=dev", "-Dotel.instrumentation.jvm-metrics.enabled=true",  "-jar", "app.jar"]


### PR DESCRIPTION
## What
> 무엇을 작업했는지 간결하게 적습니다.

→ GC 메트릭 수집을 위해 Dokcer file 수정 

## Why
> 왜 이 작업을 했는지 설명합니다.

→기존 설정에서는 Signoz에 `jvm.gc.pause` 등의 GC 관련 지표가 수집되지 않아, JVM GC 관련 모니터링이 불가능했습니다.

## Changes
> 주요 변경사항을 적습니다.

→ `otel.instrumentation.jvm-metrics.enabled=true` 옵션 추가

## Related Issue
> 관련 이슈 번호를 연결합니다.

→https://github.com/100-hours-a-week/6-nemo-be/issues/179#issue-3175466768
