### PR TITLE
hotfix/cors 문제, 캐싱 문제 해결

### DIFF
--- a/.github/workflows/v2-prod-cicd.yaml
+++ b/.github/workflows/v2-prod-cicd.yaml
@@ -1,0 +1,108 @@
+name: Backend CI for v2-prod
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: '릴리즈 버전 태그 (예: v1.3.0)'
+        required: true
+
+jobs:
+  build-and-deploy:
+    name: Build & Deploy to MIG
+    runs-on: ubuntu-latest
+    environment: prod
+
+    env:
+      REGION: asia-northeast3
+      REPOSITORY: registry
+      SERVICE: backend
+      ENVIRONMENT: prod
+      MACHINE_TYPE: e2-standard-2
+      IMAGE_NAME: be-deploy-server-image
+      BOOT_DISK_SIZE: 80GB
+      BOOT_DISK_TYPE: pd-balanced
+      NETWORK: v2-nemo-prod
+      SUBNET: prod-backend
+      NETWORK_TAG: backend-prod
+      STARTUP_SCRIPT_PATH: /home/ubuntu/nemo/cloud/v2/scripts/startup.sh
+      SHUTDOWN_SCRIPT_PATH: /home/ubuntu/nemo/cloud/v2/scripts/shutdown.sh
+      MIG_NAME: backend-instance-group
+      ROLLING_MINIMAL_ACTION: restart
+      ROLLING_MAX_SURGE: 2
+      ROLLING_MAX_UNAVAILABLE: 2
+
+    steps:
+
+    - name: Checkout Code
+      uses: actions/checkout@v3
+
+    - name: Authenticate to Google Cloud
+      uses: google-github-actions/auth@v2
+      with:
+        credentials_json: '${{ secrets.GCP_SA_KEY_PROD }}'
+
+    - name: Set GCP Project
+      run: gcloud config set project ${{ secrets.GCP_PROJECT_ID_PROD }}
+
+    - name: Set image tags and URI
+      run: |
+        TIME_TAG="${{ env.ENVIRONMENT }}-$(TZ=Asia/Seoul date +'%Y%m%d-%H%M')"
+        echo "TIME_TAG=$TIME_TAG" >> $GITHUB_ENV
+
+        VERSION_TAG="prod-${{ github.event.inputs.version }}"
+        echo "VERSION_TAG=$VERSION_TAG" >> $GITHUB_ENV
+
+        IMAGE_URI="${{ env.REGION }}-docker.pkg.dev/${{ secrets.GCP_PROJECT_ID_PROD }}/${{ env.REPOSITORY }}/${{ env.SERVICE }}"
+        echo "IMAGE_URI=$IMAGE_URI" >> $GITHUB_ENV
+
+    - name: Set up Docker Buildx
+      uses: docker/setup-buildx-action@v3
+
+    - name: Configure Docker for Artifact Registry
+      run: gcloud auth configure-docker ${{ env.REGION }}-docker.pkg.dev --quiet
+
+    - name: Gradle Build
+      env:
+        SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
+      run: |
+        ./gradlew clean build --no-daemon
+
+    - name: Build and Push Docker Image
+      run: |
+        docker buildx build \
+          --no-cache \
+          --platform linux/amd64 \
+          -t "${IMAGE_URI}:${TIME_TAG}" \
+          -t "${IMAGE_URI}:${{ env.ENVIRONMENT }}-latest" \
+          -t "${IMAGE_URI}:${VERSION_TAG}" \
+          --push .
+
+    - name: Create Instance Template & Start MIG Rolling Update
+      run: |
+        TEMPLATE_NAME="${{ env.SERVICE }}-${{ env.ENVIRONMENT }}-template-${{ env.TIME_TAG }}"
+        echo "🔧 템플릿 이름: $TEMPLATE_NAME"
+
+        STARTUP_SCRIPT="bash ${{ env.STARTUP_SCRIPT_PATH }} ${{ env.SERVICE }} ${{ env.ENVIRONMENT }}"
+        SHUTDOWN_SCRIPT="bash ${{ env.SHUTDOWN_SCRIPT_PATH }} ${{ env.SERVICE }} ${{ env.ENVIRONMENT }}"
+
+        gcloud compute instance-templates create "$TEMPLATE_NAME" \
+          --region="${{ env.REGION }}" \
+          --machine-type="${{ env.MACHINE_TYPE }}" \
+          --image="${{ env.IMAGE_NAME }}" \
+          --image-project="${{ secrets.GCP_PROJECT_ID_PROD }}" \
+          --boot-disk-size="${{ env.BOOT_DISK_SIZE }}" \
+          --boot-disk-type="${{ env.BOOT_DISK_TYPE }}" \
+          --network="${{ env.NETWORK }}" \
+          --subnet="${{ env.SUBNET }}" \
+          --tags="${{ env.NETWORK_TAG }}" \
+          --no-address \
+          --scopes="cloud-platform" \
+          --metadata=startup-script="$STARTUP_SCRIPT",shutdown-script="$SHUTDOWN_SCRIPT"
+
+        gcloud compute instance-groups managed rolling-action start-update "${{ env.MIG_NAME }}" \
+          --region="${{ env.REGION }}" \
+          --version=template="$TEMPLATE_NAME" \
+          --minimal-action="${{ env.ROLLING_MINIMAL_ACTION }}" \
+          --max-surge="${{ env.ROLLING_MAX_SURGE }}" \
+          --max-unavailable="${{ env.ROLLING_MAX_UNAVAILABLE }}"

--- a/src/main/java/kr/ai/nemo/domain/auth/controller/AuthController.java
+++ b/src/main/java/kr/ai/nemo/domain/auth/controller/AuthController.java
@@ -95,7 +95,7 @@ public class AuthController {
     if (refreshToken != null && !refreshToken.isEmpty()) {
       oauthService.invalidateRefreshToken(refreshToken);
     }
-
+    tokenManager.clearAccessTokenCookie(response);
     tokenManager.clearRefreshTokenCookie(response);
 
     return ResponseEntity.ok(BaseApiResponse.success(SuccessCode.SUCCESS));

--- a/src/main/java/kr/ai/nemo/domain/auth/service/TokenManager.java
+++ b/src/main/java/kr/ai/nemo/domain/auth/service/TokenManager.java
@@ -1,8 +1,7 @@
+
 package kr.ai.nemo.domain.auth.service;
 
-import jakarta.servlet.http.Cookie;
 import jakarta.servlet.http.HttpServletResponse;
-import java.time.Duration;
 import java.time.LocalDateTime;
 import kr.ai.nemo.global.aop.logging.TimeTrace;
 import kr.ai.nemo.domain.auth.domain.UserToken;
@@ -16,9 +15,15 @@ import org.springframework.stereotype.Service;
 @Service
 @RequiredArgsConstructor
 public class TokenManager {
+
+  private static final int MILLISECONDS_TO_SECONDS = 1000;
+  private static final int COOKIE_MAX_AGE_EXPIRED = 0;
+  private static final String SET_COOKIE_HEADER = "Set-Cookie";
+
   private final JwtProvider jwtProvider;
   private final UserTokenService userTokenService;
 
+  // 토큰 생성 메서드들
   public String createAccessToken(Long userId) {
     return jwtProvider.createAccessToken(userId);
   }
@@ -27,19 +32,13 @@ public class TokenManager {
     return jwtProvider.createRefreshToken(userId);
   }
 
+  // 토큰 저장 메서드
   public void saveOrUpdateToken(User user, String provider, String refreshToken,
       String device, LocalDateTime expiryDate) {
     userTokenService.saveOrUpdateToken(user, provider, refreshToken, device, expiryDate);
   }
 
-  public void setRefreshTokenInCookie(HttpServletResponse response, String refreshToken) {
-    Cookie cookie = new Cookie(AuthConstants.REFRESH_TOKEN_COOKIE_NAME, refreshToken);
-    cookie.setHttpOnly(true);
-    cookie.setSecure(true);
-    cookie.setPath("/");
-    cookie.setMaxAge((int) (jwtProvider.getRefreshTokenValidity() / 1000)); // 초 단위
-    response.addCookie(cookie);
-  }
+  // 토큰 재발급 메서드
   @TimeTrace
   public String reissueAccessToken(String refreshToken) {
     UserToken userToken = userTokenService.findValidToken(refreshToken);
@@ -48,21 +47,31 @@ public class TokenManager {
     return jwtProvider.createAccessToken(user.getId());
   }
 
+  // 쿠키 설정 메서드들
+  public void setRefreshTokenInCookie(HttpServletResponse response, String refreshToken) {
+    int maxAge = (int) (jwtProvider.getRefreshTokenValidity() / MILLISECONDS_TO_SECONDS);
+    ResponseCookie cookie = createCookie(AuthConstants.REFRESH_TOKEN_COOKIE_NAME, refreshToken, maxAge);
+    response.addHeader(SET_COOKIE_HEADER, cookie.toString());
+  }
+
   public void clearRefreshTokenCookie(HttpServletResponse response) {
-    Cookie cookie = new Cookie(AuthConstants.REFRESH_TOKEN_COOKIE_NAME, null);
-    cookie.setHttpOnly(true);
-    cookie.setSecure(true);
-    cookie.setPath("/");
-    cookie.setMaxAge(0);
-    response.addCookie(cookie);
+    ResponseCookie cookie = createCookie(AuthConstants.REFRESH_TOKEN_COOKIE_NAME, "", COOKIE_MAX_AGE_EXPIRED);
+    response.addHeader(SET_COOKIE_HEADER, cookie.toString());
   }
 
   public void clearAccessTokenCookie(HttpServletResponse response) {
-    Cookie cookie = new Cookie(AuthConstants.ACCESS_TOKEN_COOKIE_NAME, null);
-    cookie.setHttpOnly(true);
-    cookie.setSecure(true);
-    cookie.setPath("/");
-    cookie.setMaxAge(0);
-    response.addCookie(cookie);
+    ResponseCookie cookie = createCookie(AuthConstants.ACCESS_TOKEN_COOKIE_NAME, "", COOKIE_MAX_AGE_EXPIRED);
+    response.addHeader(SET_COOKIE_HEADER, cookie.toString());
+  }
+
+  // 공통 쿠키 생성 메서드
+  private ResponseCookie createCookie(String name, String value, int maxAge) {
+    return ResponseCookie.from(name, value)
+        .httpOnly(true)
+        .secure(true)
+        .path("/")
+        .maxAge(maxAge)
+        .sameSite("None")
+        .build();
   }
 }

--- a/src/main/java/kr/ai/nemo/domain/auth/service/TokenManager.java
+++ b/src/main/java/kr/ai/nemo/domain/auth/service/TokenManager.java
@@ -56,4 +56,13 @@ public class TokenManager {
     cookie.setMaxAge(0);
     response.addCookie(cookie);
   }
+
+  public void clearAccessTokenCookie(HttpServletResponse response) {
+    Cookie cookie = new Cookie(AuthConstants.ACCESS_TOKEN_COOKIE_NAME, null);
+    cookie.setHttpOnly(true);
+    cookie.setSecure(true);
+    cookie.setPath("/");
+    cookie.setMaxAge(0);
+    response.addCookie(cookie);
+  }
 }

--- a/src/main/java/kr/ai/nemo/domain/groupparticipants/service/GroupParticipantsCommandService.java
+++ b/src/main/java/kr/ai/nemo/domain/groupparticipants/service/GroupParticipantsCommandService.java
@@ -64,9 +64,8 @@ public class GroupParticipantsCommandService {
 
     if (isNewParticipant) {
       incrementCapacity(capacityKey);
-      group.addCurrentUserCount();
     }
-
+    group.addCurrentUserCount();
     scheduleParticipantsService.addParticipantToUpcomingSchedules(group, user);
     groupCacheService.evictGroupDetailStatic(groupId);
     groupCacheService.deleteGroupListCaches();

--- a/src/main/java/kr/ai/nemo/global/config/CorsConfig.java
+++ b/src/main/java/kr/ai/nemo/global/config/CorsConfig.java
@@ -13,7 +13,7 @@ public class CorsConfig {
   @Bean
   public CorsConfigurationSource corsConfigurationSource() {
     CorsConfiguration configuration = new CorsConfiguration();
-    configuration.setAllowedOrigins(List.of("https://dev.nemo.ai.kr", "http://localhost:3000", "http://localhost:8000"));
+    configuration.setAllowedOrigins(List.of("https://dev.nemo.ai.kr", "http://localhost:3000", "http://localhost:8000", "https://localhost:3000"));
     configuration.setAllowedMethods(List.of("GET", "POST", "PUT", "DELETE", "PATCH", "OPTIONS"));
     configuration.setAllowedHeaders(List.of("*"));
     configuration.setAllowCredentials(true);

--- a/src/main/java/kr/ai/nemo/global/util/AuthConstants.java
+++ b/src/main/java/kr/ai/nemo/global/util/AuthConstants.java
@@ -3,6 +3,7 @@ package kr.ai.nemo.global.util;
 public class AuthConstants {
   // 쿠키 관련
   public static final String REFRESH_TOKEN_COOKIE_NAME = "refresh_token";
+  public static final String ACCESS_TOKEN_COOKIE_NAME = "access_token";
 
   // 헤더 관련
   public static final String AUTHORIZATION_HEADER = "Authorization";

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -1,0 +1,58 @@
+spring:
+  datasource:
+    url: jdbc:mysql://${DB_URL}?serverTimezone=Asia/Seoul&characterEncoding=UTF-8
+    username: ${USERNAME}
+    password: ${PASSWORD}
+
+  data:
+    redis:
+      host: ${REDIS_URL}
+      port: ${REDIS_PORT:6379}
+      timeout: 2s
+      password: ${REDIS_PASSWORD}
+
+  jpa:
+    hibernate:
+      ddl-auto: validate
+    show-sql: true
+
+management:
+  tracing:
+    sampling:
+      probability: 0.1
+  otlp:
+    metrics:
+      export:
+        enabled: true
+    tracing:
+      endpoint: http://35.216.67.116:4318
+      export:
+        enabled: true
+  endpoints:
+    web:
+      exposure:
+        include: health, info, metrics
+  endpoint:
+    health:
+      show-details: when-authorized
+
+logging:
+  level:
+    org.hibernate.SQL: DEBUG
+    org.hibernate.type.descriptor.sql.BasicBinder: TRACE
+    com.nemo: DEBUG
+  file:
+    name: logs/nemo-dev.log
+  logback:
+    rolling policy:
+      max-file-size: 100MB
+      max-history: 7
+
+sentry:
+  dsn: ${SENTRY_DSN}
+  environment: development
+  release: ${SENTRY_RELEASE:dev}
+  traces-sample-rate: 0.1
+  send-default-pii: false
+  enable-tracing: true
+  enabled: true

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -1,0 +1,48 @@
+spring:
+  # MySQL 주소
+  datasource:
+    url: jdbc:mysql://localhost:3306/nemo_db?serverTimezone=Asia/Seoul&characterEncoding=UTF-8
+    username: ${USERNAME}
+    password: ${PASSWORD}
+
+  # redis 주소
+  data:
+    redis:
+      host: localhost
+      port: 6379
+      timeout: 2s
+      password: # 로컬에서는 비밀번호 없음
+
+  jpa:
+    hibernate:
+      ddl-auto: none
+    show-sql: true
+
+management:
+  tracing:
+    sampling:
+      probability: 0.0  # 로컬에서는 트레이싱 비활성화
+  otlp:
+    metrics:
+      export:
+        enabled: false
+    tracing:
+      export:
+        enabled: false
+  endpoints:
+    web:
+      exposure:
+        include: health, info, metrics
+  endpoint:
+    health:
+      show-details: always
+
+logging:
+  level:
+    org.hibernate.SQL: DEBUG
+    org.hibernate.type.descriptor.sql.BasicBinder: TRACE
+    org.springframework.security: DEBUG
+    com.nemo: DEBUG
+
+sentry:
+  enabled: false

--- a/src/main/resources/application-prod.yml
+++ b/src/main/resources/application-prod.yml
@@ -1,0 +1,65 @@
+spring:
+  datasource:
+    url: jdbc:mysql://${DB_URL}?serverTimezone=Asia/Seoul&characterEncoding=UTF-8
+    username: ${USERNAME}
+    password: ${PASSWORD}
+    hikari:
+      maximum-pool-size: 20
+      minimum-idle: 5
+      connection-timeout: 20000
+      idle-timeout: 300000
+      max-lifetime: 1200000
+
+  data:
+    redis:
+      host: ${REDIS_URL}
+      port: ${REDIS_PORT:6379}
+      timeout: 2s
+      password: ${REDIS_PASSWORD}
+
+  jpa:
+    hibernate:
+      ddl-auto: none
+    show-sql: false
+
+management:
+  tracing:
+    sampling:
+      probability: 1.0
+  otlp:
+    metrics:
+      export:
+        enabled: true
+    tracing:
+      endpoint: http://35.216.67.116:4318
+      export:
+        enabled: true
+  endpoints:
+    web:
+      exposure:
+        include: health, info, metrics
+  endpoint:
+    health:
+      show-details: never
+
+logging:
+  level:
+    org.hibernate.SQL: ERROR
+    org.hibernate.type.descriptor.sql.BasicBinder: ERROR
+    com.nemo: INFO
+    root: INFO
+  file:
+    name: logs/nemo.log
+  logback:
+    rollingpolicy:
+      max-file-size: 100MB
+      max-history: 30
+
+sentry:
+  dsn: ${SENTRY_DSN}
+  environment: ${SENTRY_ENV:production}
+  release: ${SENTRY_RELEASE}
+  traces-sample-rate: ${SENTRY_SAMPLE_RATE:0.1}
+  send-default-pii: ${SENTRY_SEND_PII:false}
+  enable-tracing: true
+  enabled: true

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -2,78 +2,46 @@ spring:
   application:
     name: nemo
 
+  # 활성 프로필
   profiles:
     active: ${SPRING_PROFILES_ACTIVE:local}
 
+  # 파일 업로드 설정 (이미지 파일)
   servlet:
     multipart:
-      max-file-size: ${IMAGE_FILE_BYTE}
-      max-request-size: ${IMAGE_REQUEST_BYTE}
+      max-file-size: ${IMAGE_FILE_BYTE:10MB}
+      max-request-size: ${IMAGE_REQUEST_BYTE:50MB}
 
+  # MySQL 드라이버
   datasource:
-    url: jdbc:mysql://${DB_URL}?serverTimezone=Asia/Seoul&characterEncoding=UTF-8
-    username: ${USERNAME}
-    password: ${PASSWORD}
     driver-class-name: com.mysql.cj.jdbc.Driver
 
-  data:
-    redis:
-      host: ${REDIS_URL:localhost}
-      port: ${REDIS_PORT:6379}
-      timeout: 2s
-      password: ${REDIS_PASSWORD}
-
+  # MySQL 방언
   jpa:
-    hibernate:
-      ddl-auto: none
-    show-sql: true
+    database-platform: org.hibernate.dialect.MySQL8Dialect
     properties:
       hibernate:
+        # sql 포매팅 (가독성 향상)
         format_sql: true
-    database-platform: org.hibernate.dialect.MySQL8Dialect
 
   messages:
     basename: validation
     encoding: UTF-8
-
 
 oauth:
   kakao:
     rest-api-key: ${KAKAO_REST_API_KEY}
     redirect-uri: ${KAKAO_REDIRECT_URI}
 
-
 jwt:
   secret: ${JWT_SECRET}
-  access-token-validity: ${ACCESS_TOKEN_EXPIRATION}
-  refresh-token-validity: ${REFRESH_TOKEN_EXPIRATION}
-
-
-management:
-  tracing:
-    sampling:
-      probability: 1.0
-  otlp:
-    metrics:
-      export:
-        enabled: true
-    tracing:
-      endpoint: http://35.216.67.116:4318
-      export:
-        enabled: true
-  endpoints:
-    web:
-      exposure:
-        include: health, info, metrics
-  endpoint:
-    health:
-      show-details: never
-
+  access-token-validity: ${ACCESS_TOKEN_EXPIRATION:3600000}
+  refresh-token-validity: ${REFRESH_TOKEN_EXPIRATION:604800000}
 
 server:
   forward-headers-strategy: framework
 
-
+# 이미지 파일 s3 사용
 cloud:
   aws:
     s3:
@@ -82,9 +50,9 @@ cloud:
       access-key: ${CLOUD_AWS_CREDENTIALS_ACCESS_KEY}
       secret-key: ${CLOUD_AWS_CREDENTIALS_SECRET_KEY}
     region:
-      static: ${AWS_REGION}
+      static: ${AWS_REGION:ap-northeast-2}
 
-
+# AI 서버 주소
 ai:
   service:
     url: ${AI_SERVICE_URL}
@@ -99,13 +67,3 @@ ai:
         group-delete: /ai/v2/groups/delete
         group-join: /ai/v2/groups/participants
         group-leave: /ai/v2/groups/participants/delete
-
-
-sentry:
-  dsn: ${SENTRY_DSN}
-  environment: ${SENTRY_ENV}
-  release: ${SENTRY_RELEASE}
-  traces-sample-rate: ${SENTRY_SAMPLE_RATE:0.1}
-  send-default-pii: ${SENTRY_SEND_PII:false}
-  enable-tracing: true
-  enabled: false

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -62,6 +62,7 @@ ai:
         group-recommend-freeform: /ai/v2/groups/recommendations/freeform
         group-recommend-questions: /ai/v2/groups/recommendations/questions
         group-recommend: /ai/v2/groups/recommendations
+        group-websocket: ${GROUP_CHATBOT_URI}
       group-data:
         group-create: /ai/v2/groups
         group-delete: /ai/v2/groups/delete

--- a/src/test/java/TokenGenerator.java
+++ b/src/test/java/TokenGenerator.java
@@ -1,0 +1,40 @@
+import kr.ai.nemo.domain.auth.security.JwtProvider;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import java.util.Date;
+
+public class TokenGenerator {
+    public static void main(String[] args) {
+        JwtProvider jwtProvider = new JwtProvider();
+        
+        // 실제 시크릿 키 설정
+        ReflectionTestUtils.setField(jwtProvider, "secretKeyString", "djk@dklsa2$$:SADLGSd!#vfdskdfsfsa!058@dlsj@dasd:#45fjsdjkS");
+        ReflectionTestUtils.setField(jwtProvider, "accessTokenValidity", 3600000L); // 1시간
+        ReflectionTestUtils.setField(jwtProvider, "refreshTokenValidity", 604800000L); // 1주일
+        jwtProvider.init();
+        
+        System.out.println("=== 23개의 유효한 Refresh Token 생성 ===");
+        
+        // 활성 토큰들 (15개)
+        Long[] activeUserIds = {1L, 2L, 3L, 5L, 6L, 8L, 9L, 11L, 12L, 13L, 15L, 16L, 17L, 18L, 20L};
+        String[] providers = {"KAKAO", "GOOGLE", "NAVER", "GOOGLE", "NAVER", "GOOGLE", "NAVER", "GOOGLE", "NAVER", "KAKAO", "NAVER", "KAKAO", "GOOGLE", "NAVER", "GOOGLE"};
+        
+        System.out.println("-- 활성 토큰들 (15개)");
+        for (int i = 0; i < activeUserIds.length; i++) {
+            String refreshToken = jwtProvider.createRefreshToken(activeUserIds[i]);
+            System.out.println("User " + activeUserIds[i] + " (" + providers[i] + "): " + refreshToken);
+        }
+        
+        // 만료된 토큰들 (8개) - 실제로는 과거 시점에 생성된 것처럼 시뮬레이션
+        Long[] expiredUserIds = {1L, 2L, 4L, 7L, 10L, 14L, 19L, 4L};
+        String[] expiredProviders = {"KAKAO", "GOOGLE", "KAKAO", "KAKAO", "KAKAO", "GOOGLE", "KAKAO", "NAVER"};
+        
+        System.out.println("\n-- 만료된 토큰들 (8개)");
+        for (int i = 0; i < expiredUserIds.length; i++) {
+            String refreshToken = jwtProvider.createRefreshToken(expiredUserIds[i]);
+            System.out.println("User " + expiredUserIds[i] + " (" + expiredProviders[i] + "): " + refreshToken);
+        }
+        
+        System.out.println("\n총 23개의 토큰 생성 완료!");
+    }
+}


### PR DESCRIPTION
## What
> 무엇을 작업했는지 간결하게 적습니다.

→ application을 local, dev, prod를 따로 관리합니다.
→ 캐싱으로 인한 문제를 해결합니다.
→ https로 들어오는 cors를 허용합니다.

## Why
> 왜 이 작업을 했는지 설명합니다.

→ list가 캐싱되어 페이지가 넘어가도 중복되는 모임 list가 출력되는 오류를 해결합니다.
→ AT 검증을 쿠키로 변경함에 따라 FE 가 local에서 테스트할 수 있도록 cors를 허용합니다.
→ application.yml 관리의 필요성을 느껴 분리하였습니다.

## Changes
> 주요 변경사항을 적습니다.

→ 캐싱 무효화 파일 분리, 키 값 별도 파일 관리
→ cors에 htttps://localhost:3000 추가
→ application.yml 파일 분리

## Related Issue
> 관련 이슈 번호를 연결합니다.

→ #200 
