### PR TITLE
Feat: OTEL_ENVIRONMENT를 브랜치별로 Secret 분리 및 적용

### DIFF
--- a/.github/workflows/v2-dev-cicd.yaml
+++ b/.github/workflows/v2-dev-cicd.yaml
@@ -2,7 +2,7 @@ name: Backend CI/CD for v2-dev
 
 on:
   push:
-    branches: [ develop ]
+    branches: [ infra/signoz-refactor , develop ]
 
 jobs:
   build-and-deploy:
@@ -42,6 +42,13 @@ jobs:
     - name: Configure Docker for Artifact Registry
       run: gcloud auth configure-docker ${{ env.REGION }}-docker.pkg.dev --quiet
 
+    - name: Load OTEL_ENVIRONMENT from GCP Secret Manager
+      run: |
+        gcloud secrets versions access latest --secret="backend-env-dev" \
+          | grep '=' \
+          | grep -v '^[[:space:]]*$' \
+          >> $GITHUB_ENV
+
     - name: Gradle Build
       env:
         SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
@@ -50,15 +57,17 @@ jobs:
 
     - name: Build and Push Docker Image
       run: |
-        echo Checking pushed image: ${IMAGE_URI}:${TIME_TAG}"
-        echo Checking pushed image: ${IMAGE_URI}:${{ env.ENVIRONMENT }}-latest"
+        echo "Checking pushed image: ${IMAGE_URI}:${TIME_TAG}"
+        echo "Checking pushed image: ${IMAGE_URI}:${{ env.ENVIRONMENT }}-latest"
 
         docker buildx build \
           --no-cache \
           --platform linux/amd64 \
+          --build-arg "OTEL_ENVIRONMENT=${{ env.OTEL_ENVIRONMENT }}" \
           -t "${IMAGE_URI}:${TIME_TAG}" \
           -t "${IMAGE_URI}:${{ env.ENVIRONMENT }}-latest" \
-          --push .
+          --push \
+          .
 
     - name: Deploy via Bastion to Dev Server
       uses: appleboy/ssh-action@v1.0.0

--- a/.github/workflows/v2-dev-cicd.yaml
+++ b/.github/workflows/v2-dev-cicd.yaml
@@ -2,7 +2,8 @@ name: Backend CI/CD for v2-dev
 
 on:
   push:
-    branches: [ infra/signoz-refactor , develop ]
+    branches:
+      - develop
 
 jobs:
   build-and-deploy:

--- a/.github/workflows/v2-prod-cicd.yaml
+++ b/.github/workflows/v2-prod-cicd.yaml
@@ -87,7 +87,9 @@ jobs:
           -t "${IMAGE_URI}:${TIME_TAG}" \
           -t "${IMAGE_URI}:${{ env.ENVIRONMENT }}-latest" \
           -t "${IMAGE_URI}:${VERSION_TAG}" \
-          --push .
+          --push \
+          .
+
 
     - name: Create Instance Template & Start MIG Rolling Update
       run: |

--- a/.github/workflows/v2-prod-cicd.yaml
+++ b/.github/workflows/v2-prod-cicd.yaml
@@ -8,7 +8,7 @@ on:
         required: true
   push:
     branches:
-      - infra/fix-cicd
+      - main
 
 jobs:
   build-and-deploy:
@@ -65,6 +65,13 @@ jobs:
     - name: Configure Docker for Artifact Registry
       run: gcloud auth configure-docker ${{ env.REGION }}-docker.pkg.dev --quiet
 
+    - name: Load OTEL_ENVIRONMENT from GCP Secret Manager
+      run: |
+        gcloud secrets versions access latest --secret="backend-env-prod" \
+          | grep '=' \
+          | grep -v '^[[:space:]]*$' \
+          >> $GITHUB_ENV
+
     - name: Gradle Build
       env:
         SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
@@ -76,6 +83,7 @@ jobs:
         docker buildx build \
           --no-cache \
           --platform linux/amd64 \
+          --build-arg "OTEL_ENVIRONMENT=${{ env.OTEL_ENVIRONMENT }}" \
           -t "${IMAGE_URI}:${TIME_TAG}" \
           -t "${IMAGE_URI}:${{ env.ENVIRONMENT }}-latest" \
           -t "${IMAGE_URI}:${VERSION_TAG}" \

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,4 +9,20 @@ COPY build/libs/*.jar app.jar
 
 EXPOSE 8080
 
-ENTRYPOINT ["java", "-javaagent:/app/opentelemetry-javaagent.jar", "-Dotel.service.name=backend-service", "-Dotel.exporter.otlp.endpoint=http://35.216.67.116:4317", "-Dotel.exporter.otlp.protocol=grpc", "-Dotel.resource.attributes=deployment.environment=dev", "-Dotel.instrumentation.jvm-metrics.enabled=true", "-Dotel.instrumentation.runtime-telemetry.enabled=true",  "-jar", "app.jar"]
+ARG OTEL_ENVIRONMENT
+
+ENV OTEL_SERVICE_NAME=backend-service
+ENV OTEL_EXPORTER_OTLP_ENDPOINT=http://35.216.67.116:4317
+ENV OTEL_ENVIRONMENT=${OTEL_ENVIRONMENT}
+
+
+ENTRYPOINT sh -c "java \
+  -javaagent:/app/opentelemetry-javaagent.jar \
+  -Dotel.service.name=\${OTEL_SERVICE_NAME} \
+  -Dotel.exporter.otlp.endpoint=\${OTEL_EXPORTER_OTLP_ENDPOINT} \
+  -Dotel.exporter.otlp.protocol=grpc \
+  -Dotel.resource.attributes=deployment.environment=\${OTEL_ENVIRONMENT} \
+  -Dotel.instrumentation.jvm-metrics.enabled=true \
+  -Dotel.instrumentation.runtime-telemetry.enabled=true \
+  -Dotel.metric.export.interval=5000 \
+  -jar app.jar"


### PR DESCRIPTION
## What
> 무엇을 작업했는지 간결하게 적습니다.

→ GitHub Actions에서 브랜치(develop, main)에 따라 Secret Manager에서 서로 다른 환경변수(backend-env-dev, backend-env-prod)를 불러오도록 CI 구성 수정

## Why
> 왜 이 작업을 했는지 설명합니다.

→ 개발/운영 환경을 명확히 분리하고, OTEL 환경 값(OTEL_ENVIRONMENT)을 공통 Dockerfile에 안전하게 주입하기 위함
→ main 병합 시에도 prod 값을 자동 적용하기 위해

## Changes
> 주요 변경사항을 적습니다.

→ develop 브랜치: backend-env-dev에서 값 로드
→ main 브랜치: backend-env-prod에서 값 로드
→ 불필요한 하드코딩 제거 및 Secret 기반 안전한 환경 구분


## Related Issue
> 관련 이슈 번호를 연결합니다.

#179 