### PR TITLE
v3 에러 해결

### DIFF
--- a/src/main/java/kr/ai/nemo/domain/scheduleparticipants/repository/ScheduleParticipantRepository.java
+++ b/src/main/java/kr/ai/nemo/domain/scheduleparticipants/repository/ScheduleParticipantRepository.java
@@ -27,26 +27,30 @@ public interface ScheduleParticipantRepository extends JpaRepository<SchedulePar
   Optional<ScheduleParticipant> findByScheduleIdAndUserId(Long scheduleId, Long userId);
 
   @Query("""
-            SELECT new kr.ai.nemo.domain.schedule.dto.response.ScheduleInfoProjection(
-        sp.schedule.id,
-        sp.schedule.title,
-        sp.schedule.description,
-        sp.schedule.address,
-        sp.schedule.status,
-        sp.schedule.currentUserCount,
-        sp.schedule.group.id,
-        sp.schedule.group.name,
-        sp.schedule.owner.nickname,
-        sp.schedule.startAt,
+    SELECT new kr.ai.nemo.domain.schedule.dto.response.ScheduleInfoProjection(
+        s.id,
+        s.title,
+        s.description,
+        s.address,
+        s.status,
+        s.currentUserCount,
+        g.id,
+        g.name,
+        o.nickname,
+        s.startAt,
         sp.status
+    )
+    FROM ScheduleParticipant sp
+    JOIN sp.schedule s
+    JOIN s.group g
+    JOIN s.owner o
+    WHERE sp.user.id = :userId
+      AND s.status = 'RECRUITING'
+      AND EXISTS (
+        SELECT 1 FROM GroupParticipants gp
+        WHERE gp.group.id = g.id AND gp.user.id = :userId
       )
-      FROM ScheduleParticipant sp
-      JOIN sp.schedule s
-      JOIN s.group g
-      JOIN s.owner o
-      WHERE sp.user.id = :userId
-        AND sp.schedule.status = 'RECRUITING'
-      ORDER BY sp.updatedAt ASC
-      """)
+    ORDER BY sp.updatedAt ASC
+""")
   List<ScheduleInfoProjection> findUserRecruitingSchedules(Long userId);
 }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -48,6 +48,7 @@ spring:
       properties:
         socket.send.buffer.bytes: 102400
         socket.receive.buffer.bytes: 102400
+      retries: 3
 
     # Consumer 설정
     consumer:


### PR DESCRIPTION
## What
> 무엇을 작업했는지 간결하게 적습니다.

→ kafka 연결이 무제한으로 되는 현상 해결
→ 나의 일정이 잘못 반환되는 에러 해결

## Why
> 왜 이 작업을 했는지 설명합니다.

→ kafka가 연결되지 않을 때, 무제한으로 재연결을 시도하는 현상을 방지하여 로그를 깔끔하게 관리합니다.
→ 이미 탈퇴한 모임의 일정도 반환되는 현상을 방지합니다.

## Changes
> 주요 변경사항을 적습니다.

→ kafka retries를 3으로 설정
→ 나의 일정 조회 쿼리 수정